### PR TITLE
Add 3D raycast and plane-aware collision to ozz_collision

### DIFF
--- a/libs/ozz_collision/CMakeLists.txt
+++ b/libs/ozz_collision/CMakeLists.txt
@@ -12,6 +12,11 @@ set(SOURCES
         src/shapes/ozz_polygon.cpp
         src/shapes/ozz_rectangle.cpp
 
+        src/raycast/ozz_plane3d.cpp
+        src/raycast/ozz_raycast.cpp
+
+        src/projection/ozz_shape_projection.cpp
+
         src/world.cpp
 )
 add_library(ozz_collision STATIC

--- a/libs/ozz_collision/include/ozz_collision/ozz_collision_projection.h
+++ b/libs/ozz_collision/include/ozz_collision/ozz_collision_projection.h
@@ -1,0 +1,7 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <ozz_collision/projection/ozz_shape_projection.h>

--- a/libs/ozz_collision/include/ozz_collision/ozz_collision_raycast.h
+++ b/libs/ozz_collision/include/ozz_collision/ozz_collision_raycast.h
@@ -1,0 +1,10 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <ozz_collision/raycast/ozz_plane3d.h>
+#include <ozz_collision/raycast/ozz_ray3d.h>
+#include <ozz_collision/raycast/ozz_raycast.h>
+#include <ozz_collision/raycast/ozz_raycast_result.h>

--- a/libs/ozz_collision/include/ozz_collision/projection/ozz_shape_projection.h
+++ b/libs/ozz_collision/include/ozz_collision/projection/ozz_shape_projection.h
@@ -1,0 +1,49 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <ozz_collision/ozz_collision_result.h>
+#include <ozz_collision/ozz_collision_shapes.h>
+#include <ozz_collision/raycast/ozz_plane3d.h>
+
+namespace OZZ::collision::projection {
+
+    // Project a 2D point from one plane's local space to another's.
+    // fromPlane local 2D → world 3D → toPlane local 2D.
+    glm::vec2 ProjectPoint(const raycast::OzzPlane3D& fromPlane,
+                           const raycast::OzzPlane3D& toPlane,
+                           const glm::vec2& localPoint);
+
+    // Project an entire shape from one plane's local space to another's.
+    // A rotated OzzRectangle becomes an OzzPolygon (4 vertices).
+    // OzzCircle stays a circle if planes are parallel, else becomes a polygon approximation.
+    shapes::OzzShapeData ProjectShape(const raycast::OzzPlane3D& fromPlane,
+                                      const raycast::OzzPlane3D& toPlane,
+                                      const shapes::OzzShapeData& shape);
+
+    // Check if two planes are coplanar (parallel normals + origins on the same plane).
+    bool ArePlanesCoplanar(const raycast::OzzPlane3D& a,
+                           const raycast::OzzPlane3D& b,
+                           float tolerance = 1e-4f);
+
+    // Collision result with world-space normal
+    struct PlaneCollisionResult {
+        OzzCollisionResult Result2D{};       // raw 2D result in the reference plane's local space
+        glm::vec3 WorldCollisionNormal{};    // collision normal mapped back to world 3D
+
+        static PlaneCollisionResult NoCollision() {
+            return {.Result2D = OzzCollisionResult::NoCollision()};
+        }
+    };
+
+    // Collide two shapes, each on their own 3D plane.
+    // Non-coplanar shapes return no collision.
+    PlaneCollisionResult IsCollidingOnPlanes(
+        const raycast::OzzPlane3D& planeA, const shapes::OzzShapeData& shapeA,
+        const raycast::OzzPlane3D& planeB, const shapes::OzzShapeData& shapeB);
+
+} // namespace OZZ::collision::projection

--- a/libs/ozz_collision/include/ozz_collision/raycast/ozz_plane3d.h
+++ b/libs/ozz_collision/include/ozz_collision/raycast/ozz_plane3d.h
@@ -1,0 +1,20 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+namespace OZZ::collision::raycast {
+    struct OzzPlane3D {
+        glm::vec3 Origin{0.f};              // shape's local (0,0) in world space
+        glm::vec3 Normal{0.f, 1.f, 0.f};    // plane normal (unit vector)
+        glm::vec3 Right{1.f, 0.f, 0.f};     // local +X axis in 3D
+        glm::vec3 Up{0.f, 0.f, -1.f};       // local +Y axis in 3D
+
+        static OzzPlane3D FromPositionAndOrientation(const glm::vec3& position, const glm::quat& orientation);
+        static OzzPlane3D FromModelMatrix(const glm::mat4& model);
+    };
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/include/ozz_collision/raycast/ozz_ray3d.h
+++ b/libs/ozz_collision/include/ozz_collision/raycast/ozz_ray3d.h
@@ -1,0 +1,14 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace OZZ::collision::raycast {
+    struct OzzRay3D {
+        glm::vec3 Origin;
+        glm::vec3 Direction; // must be normalized
+    };
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/include/ozz_collision/raycast/ozz_raycast.h
+++ b/libs/ozz_collision/include/ozz_collision/raycast/ozz_raycast.h
@@ -1,0 +1,40 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include <ozz_collision/ozz_collision_shapes.h>
+#include <ozz_collision/raycast/ozz_plane3d.h>
+#include <ozz_collision/raycast/ozz_ray3d.h>
+#include <ozz_collision/raycast/ozz_raycast_result.h>
+
+namespace OZZ::collision::raycast {
+    // Cast a ray against a single 2D shape positioned on a 3D plane
+    OzzRaycastResult3D RaycastAgainstShape(
+        const OzzRay3D& ray,
+        const OzzPlane3D& plane,
+        const shapes::OzzShapeData& shape);
+
+    // Construct a world-space ray from normalized device coordinates
+    // ndcX, ndcY are in [-1, 1] range (center of screen = 0,0)
+    OzzRay3D ScreenToRay(
+        float ndcX, float ndcY,
+        const glm::mat4& viewMatrix,
+        const glm::mat4& projectionMatrix);
+
+    // Find the closest hit among multiple targets
+    std::optional<OzzRaycastHit3D> RaycastClosest(
+        const OzzRay3D& ray,
+        std::span<const std::pair<OzzPlane3D, shapes::OzzShapeData>> targets);
+
+    // Find all hits, sorted by distance (nearest first)
+    std::vector<OzzRaycastHit3D> RaycastAll(
+        const OzzRay3D& ray,
+        std::span<const std::pair<OzzPlane3D, shapes::OzzShapeData>> targets);
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/include/ozz_collision/raycast/ozz_raycast_result.h
+++ b/libs/ozz_collision/include/ozz_collision/raycast/ozz_raycast_result.h
@@ -1,0 +1,25 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <glm/glm.hpp>
+
+namespace OZZ::collision::raycast {
+    struct OzzRaycastResult3D {
+        bool bHit{false};
+        float Distance{0.f};            // parametric t along the ray
+        glm::vec3 HitPoint3D{};         // world-space intersection point
+        glm::vec2 HitPointLocal2D{};    // hit point in the shape's local 2D space
+        glm::vec3 PlaneNormal{};        // normal of the plane that was hit
+
+        static OzzRaycastResult3D NoHit() { return {.bHit = false}; }
+    };
+
+    struct OzzRaycastHit3D {
+        OzzRaycastResult3D Result;
+        size_t TargetIndex{};            // index into the targets array
+    };
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/src/projection/ozz_shape_projection.cpp
+++ b/libs/ozz_collision/src/projection/ozz_shape_projection.cpp
@@ -1,0 +1,158 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#include "ozz_collision/projection/ozz_shape_projection.h"
+
+#include <cmath>
+
+#include "ozz_collision/shapes/ozz_circle.h"
+#include "ozz_collision/shapes/ozz_line.h"
+#include "ozz_collision/shapes/ozz_point.h"
+#include "ozz_collision/shapes/ozz_polygon.h"
+#include "ozz_collision/shapes/ozz_rectangle.h"
+
+namespace OZZ::collision::projection {
+
+    glm::vec2 ProjectPoint(const raycast::OzzPlane3D& fromPlane,
+                           const raycast::OzzPlane3D& toPlane,
+                           const glm::vec2& localPoint) {
+        // Step 1: fromPlane local 2D → world 3D
+        const glm::vec3 world3D =
+            fromPlane.Origin + localPoint.x * fromPlane.Right + localPoint.y * fromPlane.Up;
+
+        // Step 2: world 3D → toPlane local 2D
+        const glm::vec3 offset = world3D - toPlane.Origin;
+        return {glm::dot(offset, toPlane.Right), glm::dot(offset, toPlane.Up)};
+    }
+
+    bool ArePlanesCoplanar(const raycast::OzzPlane3D& a,
+                           const raycast::OzzPlane3D& b,
+                           float tolerance) {
+        // Normals must be parallel (pointing same or opposite direction)
+        if (std::abs(std::abs(glm::dot(a.Normal, b.Normal)) - 1.f) > tolerance) {
+            return false;
+        }
+        // Origins must lie on the same infinite plane
+        if (std::abs(glm::dot(b.Origin - a.Origin, a.Normal)) > tolerance) {
+            return false;
+        }
+        return true;
+    }
+
+    shapes::OzzShapeData ProjectShape(const raycast::OzzPlane3D& fromPlane,
+                                      const raycast::OzzPlane3D& toPlane,
+                                      const shapes::OzzShapeData& shape) {
+        return std::visit(
+            [&](const auto& s) -> shapes::OzzShapeData {
+                using T = std::decay_t<decltype(s)>;
+
+                if constexpr (std::is_same_v<T, shapes::OzzPoint>) {
+                    return shapes::OzzPoint{
+                        .Position = ProjectPoint(fromPlane, toPlane, s.Position),
+                    };
+                } else if constexpr (std::is_same_v<T, shapes::OzzCircle>) {
+                    // Parallel planes: circle stays a circle
+                    if (std::abs(std::abs(glm::dot(fromPlane.Normal, toPlane.Normal)) - 1.f) < 1e-4f) {
+                        return shapes::OzzCircle{
+                            .Position = ProjectPoint(fromPlane, toPlane, s.Position),
+                            .Radius = shapes::OzzCircle::GetScaledRadius(s.Radius, s.Scale),
+                        };
+                    }
+                    // Non-parallel: approximate as polygon
+                    constexpr int Segments = 16;
+                    constexpr float PI = 3.14159265359f;
+                    const float scaledRadius = shapes::OzzCircle::GetScaledRadius(s.Radius, s.Scale);
+                    std::vector<glm::vec2> verts;
+                    verts.reserve(Segments);
+                    for (int i = 0; i < Segments; ++i) {
+                        const float angle = (static_cast<float>(i) / static_cast<float>(Segments)) * 2.f * PI;
+                        const glm::vec2 localPt = s.Position + glm::vec2{
+                            std::cos(angle) * scaledRadius,
+                            std::sin(angle) * scaledRadius,
+                        };
+                        verts.push_back(ProjectPoint(fromPlane, toPlane, localPt));
+                    }
+                    return shapes::OzzPolygon{
+                        .Position = {0.f, 0.f},
+                        .Scale = {1.f, 1.f},
+                        .Vertices = std::move(verts),
+                    };
+                } else if constexpr (std::is_same_v<T, shapes::OzzRectangle>) {
+                    const glm::vec2 halfSize = s.GetScaledSize() * 0.5f;
+                    const glm::vec2 corners[4] = {
+                        s.Position + glm::vec2{-halfSize.x,  halfSize.y},
+                        s.Position + glm::vec2{ halfSize.x,  halfSize.y},
+                        s.Position + glm::vec2{ halfSize.x, -halfSize.y},
+                        s.Position + glm::vec2{-halfSize.x, -halfSize.y},
+                    };
+                    std::vector<glm::vec2> verts;
+                    verts.reserve(4);
+                    for (const auto& corner : corners) {
+                        verts.push_back(ProjectPoint(fromPlane, toPlane, corner));
+                    }
+                    return shapes::OzzPolygon{
+                        .Position = {0.f, 0.f},
+                        .Scale = {1.f, 1.f},
+                        .Vertices = std::move(verts),
+                    };
+                } else if constexpr (std::is_same_v<T, shapes::OzzLine>) {
+                    glm::vec2 scaledStart, scaledEnd;
+                    shapes::OzzLine::GetScaledEndpoints(s.Position, s.End, s.Scale, scaledStart, scaledEnd);
+                    return shapes::OzzLine{
+                        .Position = ProjectPoint(fromPlane, toPlane, scaledStart),
+                        .End = ProjectPoint(fromPlane, toPlane, scaledEnd),
+                    };
+                } else if constexpr (std::is_same_v<T, shapes::OzzPolygon>) {
+                    std::vector<glm::vec2> verts;
+                    verts.reserve(s.Vertices.size());
+                    for (const auto& v : s.Vertices) {
+                        const glm::vec2 absoluteLocal = s.Position + v * s.Scale;
+                        verts.push_back(ProjectPoint(fromPlane, toPlane, absoluteLocal));
+                    }
+                    return shapes::OzzPolygon{
+                        .Position = {0.f, 0.f},
+                        .Scale = {1.f, 1.f},
+                        .Vertices = std::move(verts),
+                    };
+                }
+            },
+            shape);
+    }
+
+    PlaneCollisionResult IsCollidingOnPlanes(
+        const raycast::OzzPlane3D& planeA, const shapes::OzzShapeData& shapeA,
+        const raycast::OzzPlane3D& planeB, const shapes::OzzShapeData& shapeB) {
+
+        if (!ArePlanesCoplanar(planeA, planeB)) {
+            return PlaneCollisionResult::NoCollision();
+        }
+
+        // Project shape B into plane A's local 2D frame
+        const auto projectedB = ProjectShape(planeB, planeA, shapeB);
+
+        // Test collision using existing 2D collision
+        const auto result2D = std::visit(
+            [](const auto& a, const auto& b) -> OzzCollisionResult {
+                return IsColliding(a, b);
+            },
+            shapeA, projectedB);
+
+        if (!result2D.bCollided) {
+            return PlaneCollisionResult::NoCollision();
+        }
+
+        // Map 2D collision normal back to world 3D
+        const glm::vec3 rawNormal =
+            result2D.CollisionNormal.x * planeA.Right +
+            result2D.CollisionNormal.y * planeA.Up;
+        const float normalLen = glm::length(rawNormal);
+        const glm::vec3 worldNormal = normalLen > 1e-6f ? rawNormal / normalLen : glm::vec3{0.f};
+
+        return {
+            .Result2D = result2D,
+            .WorldCollisionNormal = worldNormal,
+        };
+    }
+
+} // namespace OZZ::collision::projection

--- a/libs/ozz_collision/src/raycast/ozz_plane3d.cpp
+++ b/libs/ozz_collision/src/raycast/ozz_plane3d.cpp
@@ -1,0 +1,39 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#include "ozz_collision/raycast/ozz_plane3d.h"
+
+namespace OZZ::collision::raycast {
+
+    OzzPlane3D OzzPlane3D::FromPositionAndOrientation(const glm::vec3& position, const glm::quat& orientation) {
+        // Default frame: shape lies flat on XZ plane (Y-up)
+        // Right = +X, Up = -Z (so that local +Y maps to world -Z), Normal = +Y
+        const glm::vec3 right = orientation * glm::vec3{1.f, 0.f, 0.f};
+        const glm::vec3 up = orientation * glm::vec3{0.f, 0.f, -1.f};
+        const glm::vec3 normal = orientation * glm::vec3{0.f, 1.f, 0.f};
+
+        return {
+            .Origin = position,
+            .Normal = normal,
+            .Right = right,
+            .Up = up,
+        };
+    }
+
+    OzzPlane3D OzzPlane3D::FromModelMatrix(const glm::mat4& model) {
+        // Extract and normalize the axis columns from the model matrix
+        const glm::vec3 right = glm::normalize(glm::vec3{model[0]});
+        const glm::vec3 up = glm::normalize(glm::vec3{model[1]});
+        const glm::vec3 normal = glm::normalize(glm::cross(right, up));
+        const glm::vec3 origin = glm::vec3{model[3]};
+
+        return {
+            .Origin = origin,
+            .Normal = normal,
+            .Right = right,
+            .Up = up,
+        };
+    }
+
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/src/raycast/ozz_raycast.cpp
+++ b/libs/ozz_collision/src/raycast/ozz_raycast.cpp
@@ -1,0 +1,131 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#include "ozz_collision/raycast/ozz_raycast.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ozz_collision/ozz_collision_result.h"
+#include "ozz_collision/shapes/ozz_point.h"
+
+namespace OZZ::collision::raycast {
+
+    static constexpr float RayPlaneEpsilon = 1e-6f;
+
+    OzzRaycastResult3D RaycastAgainstShape(
+        const OzzRay3D& ray,
+        const OzzPlane3D& plane,
+        const shapes::OzzShapeData& shape) {
+
+        // Step 1: Ray-plane intersection
+        const float denom = glm::dot(ray.Direction, plane.Normal);
+        if (std::abs(denom) < RayPlaneEpsilon) {
+            return OzzRaycastResult3D::NoHit(); // ray is parallel to the plane
+        }
+
+        // Step 2: Compute parametric distance t
+        const float t = glm::dot(plane.Origin - ray.Origin, plane.Normal) / denom;
+        if (t < 0.f) {
+            return OzzRaycastResult3D::NoHit(); // hit is behind the ray origin
+        }
+
+        // Step 3: Compute 3D hit point
+        const glm::vec3 hitPoint3D = ray.Origin + t * ray.Direction;
+
+        // Step 4: Project to local 2D coordinates on the plane
+        const glm::vec3 offset = hitPoint3D - plane.Origin;
+        const float localX = glm::dot(offset, plane.Right);
+        const float localY = glm::dot(offset, plane.Up);
+        const glm::vec2 local2D{localX, localY};
+
+        // Step 5: Point-in-shape test using existing 2D collision
+        const auto collisionResult = std::visit(
+            [&](const auto& shapeData) -> OzzCollisionResult {
+                const shapes::OzzPoint point{.Position = local2D};
+                return IsColliding(point, shapeData);
+            },
+            shape);
+
+        if (!collisionResult.bCollided) {
+            return OzzRaycastResult3D::NoHit();
+        }
+
+        // Step 6: Return hit result
+        return {
+            .bHit = true,
+            .Distance = t,
+            .HitPoint3D = hitPoint3D,
+            .HitPointLocal2D = local2D,
+            .PlaneNormal = plane.Normal,
+        };
+    }
+
+    OzzRay3D ScreenToRay(
+        float ndcX, float ndcY,
+        const glm::mat4& viewMatrix,
+        const glm::mat4& projectionMatrix) {
+
+        const glm::mat4 invVP = glm::inverse(projectionMatrix * viewMatrix);
+
+        // Unproject near and far plane points
+        const glm::vec4 nearClip = invVP * glm::vec4{ndcX, ndcY, -1.f, 1.f};
+        const glm::vec4 farClip = invVP * glm::vec4{ndcX, ndcY, 1.f, 1.f};
+
+        const glm::vec3 nearWorld = glm::vec3{nearClip} / nearClip.w;
+        const glm::vec3 farWorld = glm::vec3{farClip} / farClip.w;
+
+        return {
+            .Origin = nearWorld,
+            .Direction = glm::normalize(farWorld - nearWorld),
+        };
+    }
+
+    std::optional<OzzRaycastHit3D> RaycastClosest(
+        const OzzRay3D& ray,
+        std::span<const std::pair<OzzPlane3D, shapes::OzzShapeData>> targets) {
+
+        std::optional<OzzRaycastHit3D> closest;
+
+        for (size_t i = 0; i < targets.size(); ++i) {
+            const auto& [plane, shape] = targets[i];
+            auto result = RaycastAgainstShape(ray, plane, shape);
+            if (result.bHit) {
+                if (!closest || result.Distance < closest->Result.Distance) {
+                    closest = OzzRaycastHit3D{
+                        .Result = result,
+                        .TargetIndex = i,
+                    };
+                }
+            }
+        }
+
+        return closest;
+    }
+
+    std::vector<OzzRaycastHit3D> RaycastAll(
+        const OzzRay3D& ray,
+        std::span<const std::pair<OzzPlane3D, shapes::OzzShapeData>> targets) {
+
+        std::vector<OzzRaycastHit3D> hits;
+
+        for (size_t i = 0; i < targets.size(); ++i) {
+            const auto& [plane, shape] = targets[i];
+            auto result = RaycastAgainstShape(ray, plane, shape);
+            if (result.bHit) {
+                hits.push_back(OzzRaycastHit3D{
+                    .Result = result,
+                    .TargetIndex = i,
+                });
+            }
+        }
+
+        std::sort(hits.begin(), hits.end(), [](const auto& a, const auto& b) {
+            return a.Result.Distance < b.Result.Distance;
+        });
+
+        return hits;
+    }
+
+} // namespace OZZ::collision::raycast

--- a/libs/ozz_collision/tests/CMakeLists.txt
+++ b/libs/ozz_collision/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ set (SOURCES
         line_collision.cpp
         rectangle_collision.cpp
         polygon_collision.cpp
+        raycast_tests.cpp
+        projection_tests.cpp
 )
 add_executable(${PROJECT_NAME} ${SOURCES})
 

--- a/libs/ozz_collision/tests/projection_tests.cpp
+++ b/libs/ozz_collision/tests/projection_tests.cpp
@@ -1,0 +1,266 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#include <gtest/gtest.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include "ozz_collision/ozz_collision_projection.h"
+#include "ozz_collision/shapes/ozz_circle.h"
+#include "ozz_collision/shapes/ozz_polygon.h"
+#include "ozz_collision/shapes/ozz_rectangle.h"
+
+using namespace OZZ::collision::projection;
+using namespace OZZ::collision::raycast;
+using namespace OZZ::collision::shapes;
+
+static constexpr float TestEpsilon = 1e-3f;
+
+// ── ProjectPoint ─────────────────────────────────────────────────────────────
+
+TEST(ProjectPoint, IdentityPlanes_NoOp) {
+    const OzzPlane3D plane{};  // default: origin at 0, Y-up, Right=+X, Up=-Z
+    const glm::vec2 point{3.f, 5.f};
+
+    const auto result = ProjectPoint(plane, plane, point);
+
+    EXPECT_NEAR(result.x, 3.f, TestEpsilon);
+    EXPECT_NEAR(result.y, 5.f, TestEpsilon);
+}
+
+TEST(ProjectPoint, BetweenTranslatedPlanes) {
+    OzzPlane3D planeA{};
+    planeA.Origin = {0.f, 0.f, 0.f};
+
+    OzzPlane3D planeB{};
+    planeB.Origin = {10.f, 0.f, 0.f};
+
+    // Point at (0,0) in planeB → world (10, 0, 0) → planeA local (10, 0)
+    const auto result = ProjectPoint(planeB, planeA, {0.f, 0.f});
+
+    EXPECT_NEAR(result.x, 10.f, TestEpsilon);
+    EXPECT_NEAR(result.y, 0.f, TestEpsilon);
+}
+
+TEST(ProjectPoint, Between90DegRotatedPlanes) {
+    // PlaneA: default (flat on XZ, Y-up)
+    const OzzPlane3D planeA{};
+
+    // PlaneB: rotated 90° around Y axis
+    // Right becomes (0,0,-1), Up stays (0,0,-1)... let me construct manually
+    const auto rot = glm::angleAxis(glm::radians(90.f), glm::vec3{0.f, 1.f, 0.f});
+    const auto planeB = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+
+    // Point at (1, 0) in planeB's local space
+    const auto result = ProjectPoint(planeB, planeA, {1.f, 0.f});
+
+    // planeB.Right after 90° Y rotation of (1,0,0) = (0,0,-1)
+    // So world3D = (0,0,0) + 1*(0,0,-1) + 0*planeB.Up = (0, 0, -1)
+    // In planeA: localX = dot((0,0,-1), (1,0,0)) = 0
+    //            localY = dot((0,0,-1), (0,0,-1)) = 1
+    EXPECT_NEAR(result.x, 0.f, TestEpsilon);
+    EXPECT_NEAR(result.y, 1.f, TestEpsilon);
+}
+
+// ── ArePlanesCoplanar ────────────────────────────────────────────────────────
+
+TEST(ArePlanesCoplanar, SamePlane_True) {
+    const OzzPlane3D a{};
+    OzzPlane3D b{};
+    b.Origin = {5.f, 0.f, 3.f};  // different origin but on Y=0 plane
+
+    EXPECT_TRUE(ArePlanesCoplanar(a, b));
+}
+
+TEST(ArePlanesCoplanar, ParallelButOffset_False) {
+    const OzzPlane3D a{};
+    OzzPlane3D b{};
+    b.Origin = {0.f, 1.f, 0.f};  // same normal but offset in Y
+
+    EXPECT_FALSE(ArePlanesCoplanar(a, b));
+}
+
+TEST(ArePlanesCoplanar, DifferentNormals_False) {
+    const OzzPlane3D a{};
+    // Plane tilted 45° around X
+    const auto rot = glm::angleAxis(glm::radians(45.f), glm::vec3{1.f, 0.f, 0.f});
+    const auto b = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+
+    EXPECT_FALSE(ArePlanesCoplanar(a, b));
+}
+
+TEST(ArePlanesCoplanar, OppositeNormals_True) {
+    // Two planes on Y=0 but with opposite normals (flipped)
+    OzzPlane3D a{};
+    OzzPlane3D b{};
+    b.Normal = {0.f, -1.f, 0.f};
+    b.Right = {1.f, 0.f, 0.f};
+    b.Up = {0.f, 0.f, 1.f};
+
+    EXPECT_TRUE(ArePlanesCoplanar(a, b));
+}
+
+// ── ProjectShape ─────────────────────────────────────────────────────────────
+
+TEST(ProjectShape, RectangleOnRotatedPlane_BecomesPolygon) {
+    const OzzPlane3D planeA{};
+
+    // PlaneB rotated 90° around Y on the same ground plane
+    const auto rot = glm::angleAxis(glm::radians(90.f), glm::vec3{0.f, 1.f, 0.f});
+    const auto planeB = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+
+    const OzzShapeData rect = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto projected = ProjectShape(planeB, planeA, rect);
+
+    // Should be a polygon with 4 vertices
+    ASSERT_TRUE(std::holds_alternative<OzzPolygon>(projected));
+    const auto& poly = std::get<OzzPolygon>(projected);
+    EXPECT_EQ(poly.Vertices.size(), 4u);
+}
+
+TEST(ProjectShape, CircleBetweenParallelPlanes_StaysCircle) {
+    OzzPlane3D planeA{};
+    OzzPlane3D planeB{};
+    planeB.Origin = {5.f, 0.f, 0.f};
+
+    const OzzShapeData circle = OzzCircle{.Position = {0.f, 0.f}, .Radius = 3.f};
+
+    const auto projected = ProjectShape(planeB, planeA, circle);
+
+    ASSERT_TRUE(std::holds_alternative<OzzCircle>(projected));
+    const auto& c = std::get<OzzCircle>(projected);
+    EXPECT_NEAR(c.Radius, 3.f, TestEpsilon);
+    // Center should be offset by the plane translation
+    EXPECT_NEAR(c.Position.x, 5.f, TestEpsilon);
+}
+
+TEST(ProjectShape, PolygonProjection) {
+    const OzzPlane3D planeA{};
+    OzzPlane3D planeB{};
+    planeB.Origin = {2.f, 0.f, 0.f};  // translated, same orientation
+
+    const OzzShapeData hex = OzzPolygon{
+        .Position = {0.f, 0.f},
+        .Vertices = {{1.f, 0.f}, {0.f, 1.f}, {-1.f, 0.f}, {0.f, -1.f}},
+    };
+
+    const auto projected = ProjectShape(planeB, planeA, hex);
+
+    ASSERT_TRUE(std::holds_alternative<OzzPolygon>(projected));
+    const auto& poly = std::get<OzzPolygon>(projected);
+    EXPECT_EQ(poly.Vertices.size(), 4u);
+    // All vertices should be shifted by +2 in X
+    EXPECT_NEAR(poly.Vertices[0].x, 3.f, TestEpsilon);
+    EXPECT_NEAR(poly.Vertices[0].y, 0.f, TestEpsilon);
+}
+
+// ── IsCollidingOnPlanes ──────────────────────────────────────────────────────
+
+TEST(IsCollidingOnPlanes, CoplanarRectangles_Colliding) {
+    const OzzPlane3D planeA{};
+    OzzPlane3D planeB{};
+    planeB.Origin = {1.f, 0.f, 0.f};  // shifted 1 unit in X, same plane
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {4.f, 4.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {4.f, 4.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    EXPECT_TRUE(result.Result2D.bCollided);
+}
+
+TEST(IsCollidingOnPlanes, CoplanarRectangles_NotColliding) {
+    const OzzPlane3D planeA{};
+    OzzPlane3D planeB{};
+    planeB.Origin = {10.f, 0.f, 0.f};  // far apart
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    EXPECT_FALSE(result.Result2D.bCollided);
+}
+
+TEST(IsCollidingOnPlanes, NonCoplanar_NoCollision) {
+    const OzzPlane3D planeA{};  // ground plane
+    // Vertical plane (standing unit)
+    const auto rot = glm::angleAxis(glm::radians(90.f), glm::vec3{1.f, 0.f, 0.f});
+    const auto planeB = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {100.f, 100.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {100.f, 100.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    EXPECT_FALSE(result.Result2D.bCollided);
+}
+
+TEST(IsCollidingOnPlanes, RotatedRectangles_Colliding) {
+    // Two rectangles on the same plane, one rotated 45° around Y
+    const OzzPlane3D planeA{};
+
+    const auto rot = glm::angleAxis(glm::radians(45.f), glm::vec3{0.f, 1.f, 0.f});
+    const auto planeB = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+
+    // Both 2x2 at origin — should overlap regardless of rotation
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    EXPECT_TRUE(result.Result2D.bCollided);
+}
+
+TEST(IsCollidingOnPlanes, RotatedRectangles_MissAfterRotation) {
+    // Rectangle A at origin, rectangle B at (1.5, 0) with 45° rotation
+    // B's corners extend further along the diagonal, so carefully positioned to miss
+    const OzzPlane3D planeA{};
+
+    const auto rot = glm::angleAxis(glm::radians(45.f), glm::vec3{0.f, 1.f, 0.f});
+    const auto planeB = OzzPlane3D::FromPositionAndOrientation({3.f, 0.f, 0.f}, rot);
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    // At distance 3 with 1x1 half-sizes, even with rotation they shouldn't collide
+    EXPECT_FALSE(result.Result2D.bCollided);
+}
+
+TEST(IsCollidingOnPlanes, WorldNormal_CorrectDirection) {
+    // Two rectangles overlapping, check that world normal is reasonable
+    OzzPlane3D planeA{};
+    OzzPlane3D planeB{};
+    planeB.Origin = {0.5f, 0.f, 0.f};  // slightly offset in X
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = IsCollidingOnPlanes(planeA, rectA, planeB, rectB);
+
+    ASSERT_TRUE(result.Result2D.bCollided);
+    // World normal should be finite (not NaN) — it may be zero if the 2D
+    // collision doesn't produce a normal for this configuration
+    EXPECT_FALSE(std::isnan(result.WorldCollisionNormal.x));
+    EXPECT_FALSE(std::isnan(result.WorldCollisionNormal.y));
+    EXPECT_FALSE(std::isnan(result.WorldCollisionNormal.z));
+}
+
+TEST(IsCollidingOnPlanes, IdenticalPlanes_SameAsRaw2D) {
+    // Both shapes on the exact same plane — should detect collision
+    const OzzPlane3D plane{};
+
+    const OzzShapeData rectA = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+    const OzzShapeData rectB = OzzRectangle{.Position = {0.5f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = IsCollidingOnPlanes(plane, rectA, plane, rectB);
+
+    // The projected rectangle becomes a polygon, so the collision path is
+    // OzzRectangle vs OzzPolygon. The key check is that collision is detected.
+    EXPECT_TRUE(result.Result2D.bCollided);
+}

--- a/libs/ozz_collision/tests/raycast_tests.cpp
+++ b/libs/ozz_collision/tests/raycast_tests.cpp
@@ -1,0 +1,308 @@
+//
+// Created by Claude on 2026-04-04.
+//
+
+#include <gtest/gtest.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include "ozz_collision/ozz_collision_raycast.h"
+#include "ozz_collision/shapes/ozz_circle.h"
+#include "ozz_collision/shapes/ozz_polygon.h"
+#include "ozz_collision/shapes/ozz_rectangle.h"
+
+using namespace OZZ::collision::raycast;
+using namespace OZZ::collision::shapes;
+
+static constexpr float TestEpsilon = 1e-4f;
+
+// ── OzzPlane3D Factories ─────────────────────────────────────────────────────
+
+TEST(OzzPlane3D, FromIdentityQuaternion) {
+    const auto plane = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, glm::quat{1.f, 0.f, 0.f, 0.f});
+
+    // Default: flat on XZ plane, Y-up
+    EXPECT_NEAR(plane.Normal.y, 1.f, TestEpsilon);
+    EXPECT_NEAR(plane.Right.x, 1.f, TestEpsilon);
+    EXPECT_NEAR(plane.Up.z, -1.f, TestEpsilon);
+}
+
+TEST(OzzPlane3D, FromPositionAndOrientation_90DegRotationAroundX) {
+    // Rotate 90 degrees around X axis: XZ plane becomes XY plane
+    const auto rot = glm::angleAxis(glm::radians(90.f), glm::vec3{1.f, 0.f, 0.f});
+    const auto plane = OzzPlane3D::FromPositionAndOrientation({5.f, 0.f, 0.f}, rot);
+
+    EXPECT_NEAR(plane.Origin.x, 5.f, TestEpsilon);
+    // Normal should now point along +Z (rotated from +Y)
+    EXPECT_NEAR(plane.Normal.z, 1.f, TestEpsilon);
+    EXPECT_NEAR(std::abs(plane.Normal.x), 0.f, TestEpsilon);
+    EXPECT_NEAR(std::abs(plane.Normal.y), 0.f, TestEpsilon);
+}
+
+TEST(OzzPlane3D, FromModelMatrix_Identity) {
+    const glm::mat4 identity{1.f};
+    const auto plane = OzzPlane3D::FromModelMatrix(identity);
+
+    EXPECT_NEAR(plane.Origin.x, 0.f, TestEpsilon);
+    EXPECT_NEAR(plane.Origin.y, 0.f, TestEpsilon);
+    EXPECT_NEAR(plane.Origin.z, 0.f, TestEpsilon);
+    EXPECT_NEAR(plane.Right.x, 1.f, TestEpsilon);
+    EXPECT_NEAR(plane.Up.y, 1.f, TestEpsilon);
+}
+
+TEST(OzzPlane3D, FromModelMatrix_WithTranslation) {
+    auto model = glm::translate(glm::mat4{1.f}, glm::vec3{3.f, 5.f, 7.f});
+    const auto plane = OzzPlane3D::FromModelMatrix(model);
+
+    EXPECT_NEAR(plane.Origin.x, 3.f, TestEpsilon);
+    EXPECT_NEAR(plane.Origin.y, 5.f, TestEpsilon);
+    EXPECT_NEAR(plane.Origin.z, 7.f, TestEpsilon);
+}
+
+// ── Ray-Plane Basics ─────────────────────────────────────────────────────────
+
+TEST(Raycast, RayHitsPlaneAtKnownDistance) {
+    // Ray pointing straight down at a flat XZ plane at Y=0
+    const OzzRay3D ray{.Origin = {0.f, 10.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};  // default: origin at 0, normal Y-up
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {100.f, 100.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    EXPECT_NEAR(result.Distance, 10.f, TestEpsilon);
+    EXPECT_NEAR(result.HitPoint3D.y, 0.f, TestEpsilon);
+}
+
+TEST(Raycast, RayParallelToPlane_NoHit) {
+    // Ray parallel to the XZ plane (moving along X)
+    const OzzRay3D ray{.Origin = {0.f, 5.f, 0.f}, .Direction = {1.f, 0.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {100.f, 100.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_FALSE(result.bHit);
+}
+
+TEST(Raycast, RayPointingAway_NoHit) {
+    // Ray pointing up, away from the plane at Y=0
+    const OzzRay3D ray{.Origin = {0.f, 5.f, 0.f}, .Direction = {0.f, 1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {100.f, 100.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_FALSE(result.bHit);
+}
+
+// ── Raycast vs Rectangle ─────────────────────────────────────────────────────
+
+TEST(Raycast, HitsRectangleCenter) {
+    // Rectangle at origin on XZ plane, 2x2
+    const OzzRay3D ray{.Origin = {0.f, 5.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    EXPECT_NEAR(result.HitPointLocal2D.x, 0.f, TestEpsilon);
+    EXPECT_NEAR(result.HitPointLocal2D.y, 0.f, TestEpsilon);
+}
+
+TEST(Raycast, MissesRectangle_HitsPlaneButOutsideShape) {
+    // Ray hits the plane but outside the rectangle bounds
+    const OzzRay3D ray{.Origin = {5.f, 5.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_FALSE(result.bHit);
+}
+
+// ── Raycast vs Circle ────────────────────────────────────────────────────────
+
+TEST(Raycast, HitsCircleOnFlatPlane) {
+    const OzzRay3D ray{.Origin = {0.f, 10.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzCircle{.Position = {0.f, 0.f}, .Radius = 5.f};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    EXPECT_NEAR(result.Distance, 10.f, TestEpsilon);
+}
+
+TEST(Raycast, MissesCircle) {
+    // Ray hits plane at local (10, 0), circle is at origin with radius 5
+    const OzzRay3D ray{.Origin = {10.f, 10.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData shape = OzzCircle{.Position = {0.f, 0.f}, .Radius = 5.f};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_FALSE(result.bHit);
+}
+
+TEST(Raycast, HitsCircleOnTiltedPlane) {
+    // Circle on a plane tilted 45 degrees around X axis
+    const auto rot = glm::angleAxis(glm::radians(45.f), glm::vec3{1.f, 0.f, 0.f});
+    const auto plane = OzzPlane3D::FromPositionAndOrientation({0.f, 0.f, 0.f}, rot);
+    const OzzShapeData shape = OzzCircle{.Position = {0.f, 0.f}, .Radius = 5.f};
+
+    // Ray going straight down should hit the tilted plane
+    const OzzRay3D ray{.Origin = {0.f, 10.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    EXPECT_NEAR(result.HitPoint3D.x, 0.f, TestEpsilon);
+}
+
+// ── Raycast vs Polygon (Hexagon) ────────────────────────────────────────────
+
+TEST(Raycast, HitsHexagonCenter) {
+    // Unit hexagon on XZ plane
+    const OzzShapeData shape = OzzPolygon{
+        .Vertices = {
+            { 0.f,     1.f  },
+            {-0.866f,  0.5f },
+            {-0.866f, -0.5f },
+            { 0.f,    -1.f  },
+            { 0.866f, -0.5f },
+            { 0.866f,  0.5f },
+        }};
+
+    const OzzRay3D ray{.Origin = {0.f, 5.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    EXPECT_NEAR(result.HitPointLocal2D.x, 0.f, TestEpsilon);
+    EXPECT_NEAR(result.HitPointLocal2D.y, 0.f, TestEpsilon);
+}
+
+TEST(Raycast, MissesHexagon) {
+    const OzzShapeData shape = OzzPolygon{
+        .Vertices = {
+            { 0.f,     1.f  },
+            {-0.866f,  0.5f },
+            {-0.866f, -0.5f },
+            { 0.f,    -1.f  },
+            { 0.866f, -0.5f },
+            { 0.866f,  0.5f },
+        }};
+
+    // Ray hits plane at (3, 0) in local space — well outside the hex
+    const OzzRay3D ray{.Origin = {3.f, 5.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_FALSE(result.bHit);
+}
+
+// ── Local 2D Projection ─────────────────────────────────────────────────────
+
+TEST(Raycast, Local2DProjection_OffCenter) {
+    // Hit a large rectangle at a known offset
+    const OzzRay3D ray{.Origin = {2.f, 10.f, -3.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};  // flat XZ, Right=+X, Up=-Z
+    const OzzShapeData shape = OzzRectangle{.Position = {0.f, 0.f}, .Size = {20.f, 20.f}};
+
+    const auto result = RaycastAgainstShape(ray, plane, shape);
+
+    EXPECT_TRUE(result.bHit);
+    // local X = dot(offset, Right) = dot((2,0,-3), (1,0,0)) = 2
+    EXPECT_NEAR(result.HitPointLocal2D.x, 2.f, TestEpsilon);
+    // local Y = dot(offset, Up) = dot((2,0,-3), (0,0,-1)) = 3
+    EXPECT_NEAR(result.HitPointLocal2D.y, 3.f, TestEpsilon);
+}
+
+// ── ScreenToRay ──────────────────────────────────────────────────────────────
+
+TEST(ScreenToRay, CenterOfScreen) {
+    // Camera at (0,10,0) looking straight down
+    const auto view = glm::lookAt(
+        glm::vec3{0.f, 10.f, 0.f},
+        glm::vec3{0.f, 0.f, 0.f},
+        glm::vec3{0.f, 0.f, -1.f});
+    const auto proj = glm::perspective(glm::radians(45.f), 1.f, 0.1f, 100.f);
+
+    const auto ray = ScreenToRay(0.f, 0.f, view, proj);
+
+    // Center of screen should produce a ray pointing roughly straight down
+    EXPECT_NEAR(ray.Direction.x, 0.f, TestEpsilon);
+    EXPECT_NEAR(ray.Direction.y, -1.f, TestEpsilon);
+    EXPECT_NEAR(ray.Direction.z, 0.f, TestEpsilon);
+}
+
+// ── Batch Queries ────────────────────────────────────────────────────────────
+
+TEST(RaycastBatch, ClosestHit) {
+    const OzzRay3D ray{.Origin = {0.f, 20.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+
+    // Two rectangles at different heights
+    OzzPlane3D planeHigh{};
+    planeHigh.Origin.y = 10.f;
+    OzzPlane3D planeLow{};
+    planeLow.Origin.y = 5.f;
+
+    const OzzShapeData rect = OzzRectangle{.Position = {0.f, 0.f}, .Size = {10.f, 10.f}};
+
+    std::vector<std::pair<OzzPlane3D, OzzShapeData>> targets = {
+        {planeLow, rect},
+        {planeHigh, rect},
+    };
+
+    const auto closest = RaycastClosest(ray, targets);
+
+    ASSERT_TRUE(closest.has_value());
+    EXPECT_EQ(closest->TargetIndex, 1u);  // planeHigh is closer (at y=10)
+    EXPECT_NEAR(closest->Result.Distance, 10.f, TestEpsilon);
+}
+
+TEST(RaycastBatch, AllHitsSorted) {
+    const OzzRay3D ray{.Origin = {0.f, 20.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+
+    OzzPlane3D plane1{};
+    plane1.Origin.y = 5.f;
+    OzzPlane3D plane2{};
+    plane2.Origin.y = 15.f;
+    OzzPlane3D plane3{};
+    plane3.Origin.y = 10.f;
+
+    const OzzShapeData rect = OzzRectangle{.Position = {0.f, 0.f}, .Size = {10.f, 10.f}};
+
+    std::vector<std::pair<OzzPlane3D, OzzShapeData>> targets = {
+        {plane1, rect},
+        {plane2, rect},
+        {plane3, rect},
+    };
+
+    const auto hits = RaycastAll(ray, targets);
+
+    ASSERT_EQ(hits.size(), 3u);
+    // Sorted by distance: plane2 (dist 5), plane3 (dist 10), plane1 (dist 15)
+    EXPECT_EQ(hits[0].TargetIndex, 1u);
+    EXPECT_EQ(hits[1].TargetIndex, 2u);
+    EXPECT_EQ(hits[2].TargetIndex, 0u);
+}
+
+TEST(RaycastBatch, NoHits) {
+    const OzzRay3D ray{.Origin = {100.f, 20.f, 0.f}, .Direction = {0.f, -1.f, 0.f}};
+    const OzzPlane3D plane{};
+    const OzzShapeData rect = OzzRectangle{.Position = {0.f, 0.f}, .Size = {2.f, 2.f}};
+
+    std::vector<std::pair<OzzPlane3D, OzzShapeData>> targets = {{plane, rect}};
+
+    const auto closest = RaycastClosest(ray, targets);
+    const auto all = RaycastAll(ray, targets);
+
+    EXPECT_FALSE(closest.has_value());
+    EXPECT_TRUE(all.empty());
+}


### PR DESCRIPTION
Add OzzRay3D, OzzPlane3D, and raycast functions for casting 3D rays against 2D shapes positioned on 3D planes. Add shape projection system for rotation-aware collision between shapes on coplanar planes — rotated rectangles are projected as polygons and tested with existing 2D collision.

Includes 36 new tests (102 total) covering raycasting, projection, coplanarity checks, and plane-aware collision.