### PR TITLE
Disable IXWebSocket's built-in auto-reconnect

### DIFF
--- a/engine/include/lights/core/net/web_socket.h
+++ b/engine/include/lights/core/net/web_socket.h
@@ -68,6 +68,9 @@ namespace OZZ::net {
         virtual void setUrl(const std::string& url) = 0;
         virtual void setOnMessageCallback(OnMessageCallback callback) = 0;
 
+        // Makes exactly one connection attempt — neither backend retries on its
+        // own. Reconnect policy (if any) is the caller's responsibility, driven
+        // by observing Close/Error events from poll() and calling start() again.
         virtual void start() = 0;
         virtual void stop() = 0;
 

--- a/engine/src/core/net/web_socket_ixwebsocket.cpp
+++ b/engine/src/core/net/web_socket_ixwebsocket.cpp
@@ -22,14 +22,8 @@ namespace OZZ::net {
         class IxWebSocket final : public WebSocket {
         public:
             IxWebSocket() {
-                // The Emscripten backend has no concept of automatic reconnection (the
-                // browser's WebSocket never retries on its own), so callers of this
-                // interface are written against "start() is a single connection
-                // attempt; reconnect policy is the caller's job" — see web_socket.h.
-                // IXWebSocket defaults to its own background auto-reconnect with
-                // exponential backoff, which silently violates that contract on
-                // desktop and can leave a caller's own reconnect state machine
-                // fighting a socket that's already retrying underneath it.
+                // We want reconnects handled explicitly at the caller level, not by
+                // IXWebSocket's own background auto-reconnect — see web_socket.h.
                 ws.disableAutomaticReconnection();
             }
 

--- a/engine/src/core/net/web_socket_ixwebsocket.cpp
+++ b/engine/src/core/net/web_socket_ixwebsocket.cpp
@@ -21,6 +21,18 @@ namespace OZZ::net {
     namespace {
         class IxWebSocket final : public WebSocket {
         public:
+            IxWebSocket() {
+                // The Emscripten backend has no concept of automatic reconnection (the
+                // browser's WebSocket never retries on its own), so callers of this
+                // interface are written against "start() is a single connection
+                // attempt; reconnect policy is the caller's job" — see web_socket.h.
+                // IXWebSocket defaults to its own background auto-reconnect with
+                // exponential backoff, which silently violates that contract on
+                // desktop and can leave a caller's own reconnect state machine
+                // fighting a socket that's already retrying underneath it.
+                ws.disableAutomaticReconnection();
+            }
+
             void setUrl(const std::string& url) override { ws.setUrl(url); }
 
             void setOnMessageCallback(OnMessageCallback callback) override {


### PR DESCRIPTION
## Summary
- `OZZ::net::WebSocket::start()` is documented (and the Emscripten backend already behaves this way) as making a single connection attempt, leaving reconnect policy to the caller.
- IXWebSocket defaults to its own background auto-reconnect with exponential backoff, silently violating that contract on desktop only.
- This surfaced as a real bug while building a reconnect state machine in `simple_mmo_client` (truck-kun): the caller's own state machine would give up and move to a "disconnected" state, then IXWebSocket would silently reconnect on its own in the background later, with nothing left listening for it — the app got permanently stuck showing itself as disconnected even though the socket had recovered.

## Test plan
- [x] Rebuilt `simple-mmo/all` in truck-kun against this branch via `-DLOCAL_LIGHTS_DIR`
- [x] Confirmed via log inspection that after disabling auto-reconnect, a dropped connection no longer gets silently "fixed" underneath the caller — the caller's own state machine now has exclusive control over reconnect attempts, matching the documented contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)