### PR TITLE
Add OZZ::net::server: generic server-side connection framework

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "worktree": {"bgIsolation": "none"}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ Keep comments short — one line, two at most. Only comment non-obvious WHY, not
 
 No references to truck-kun (or any other application-layer/game project) by name in source code or comments — Lights is a standalone engine, not coupled to a specific consumer. Refer to "downstream consumers" generically if context is needed.
 
+## Assertions
+
+Use `OZZ_ASSERT(condition, message)` (`lights/core/util/assert.h`) instead of a naked `assert()` — it logs via `spdlog::error` before asserting, so the failure is visible even in a release build where `NDEBUG` strips `assert()` (and its condition) entirely. Replace naked asserts with it opportunistically as encountered, not as a dedicated retrofit pass.
+
 ## Configure flags (when consumed via Lights's third_party)
 
 - `LOCAL_RENDERING_DIR` — path to a local `ozz_rendering` checkout; overrides the GitHub fetch.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -24,6 +24,11 @@ set(SOURCES
         src/core/net/web_socket_boost.cpp
         src/core/net/web_socket_emscripten.cpp
 
+        src/core/net/server/reactor_pool.cpp
+        src/core/net/server/connection_handler.cpp
+        src/core/net/server/connection_registry.cpp
+        src/core/net/server/server.cpp
+
         src/core/platform/window.cpp
         src/core/platform/SDL3/sdl_keys.cpp
         src/core/platform/SDL3/sdl_window.cpp
@@ -80,4 +85,9 @@ target_include_directories(${PROJECT_NAME}
 )
 target_compile_definitions(lights_engine PUBLIC ${COMPILE_DEFINITIONS})
 target_link_libraries(lights_engine PUBLIC ${OPENGL_LIBRARIES} third_party ozz_collision ozz_audio)
+
+# Networking tests need Boost, which isn't fetched on web builds (see third_party).
+if (NOT EMSCRIPTEN)
+    add_subdirectory(tests)
+endif ()
 

--- a/engine/include/lights/core/net/server/connection_delegate.h
+++ b/engine/include/lights/core/net/server/connection_delegate.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+
+namespace OZZ::net::server {
+
+    // Application-defined message handling for one connection. ConnectionHandler owns
+    // exactly one delegate at a time and always dispatches through it -- SetDelegate()
+    // swaps in a new one (e.g. auth -> gameplay) without ConnectionHandler needing to
+    // know phases exist.
+    class ConnectionDelegate {
+    public:
+        virtual ~ConnectionDelegate() = default;
+
+        // Fires exactly once, right after the handshake completes, on whichever delegate
+        // the connection factory installed. NOT re-fired across SetDelegate() transitions --
+        // a delegate installed via a transition should do "just became active" setup in
+        // its own constructor instead.
+        virtual void OnOpen() {}
+
+        virtual void OnMessage(std::span<const uint8_t> data, bool binary) = 0;
+
+        virtual void OnClose(const std::string& reason) {}
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/net/server/connection_handler.h
+++ b/engine/include/lights/core/net/server/connection_handler.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "connection_delegate.h"
+
+namespace OZZ::net::server {
+
+    namespace beast     = boost::beast;
+    namespace asio       = boost::asio;
+    namespace websocket = beast::websocket;
+    using tcp            = asio::ip::tcp;
+
+    // Pinned to the reactor thread that accepted its socket. Send()/Kill() post onto
+    // that executor, so outbox/writing/etc. need no mutex -- touched from one thread only.
+    class ConnectionHandler : public std::enable_shared_from_this<ConnectionHandler> {
+    public:
+        ConnectionHandler(tcp::socket&& socket, uint64_t id, std::function<void(uint64_t)> onClosedCallback);
+
+        uint64_t Id() const { return id; }
+
+        // Installs the message handler. Must be called (by the connection factory) before
+        // Run(), or from inside a delegate's own OnMessage() to transition phases.
+        void SetDelegate(std::shared_ptr<ConnectionDelegate> newDelegate);
+
+        // Kicks off the WebSocket accept handshake. Must be called once, after SetDelegate().
+        void Run();
+
+        // Thread-safe: queues payload, posts the write onto this connection's own executor.
+        void Send(std::string payload);
+
+        // Thread-safe: requests a graceful close, deferred until any queued sends have drained.
+        void Kill(const std::string& killReason);
+
+        std::shared_future<std::string> OnClosed();
+
+    private:
+        void onAccept(beast::error_code ec);
+        void doRead();
+        void onRead(beast::error_code ec, std::size_t bytesTransferred);
+        void onWrite(beast::error_code ec, std::size_t bytesTransferred);
+
+        void enqueueAndMaybeWrite(std::string payload);
+        void requestClose(const std::string& reason);
+        void doClose(const std::string& reason);
+
+        websocket::stream<beast::tcp_stream> ws;
+        beast::flat_buffer buffer;
+
+        uint64_t id;
+        std::function<void(uint64_t)> onClosedCallback;
+        std::shared_ptr<ConnectionDelegate> delegate;
+
+        // Only ever touched on ws.get_executor() -- see class comment.
+        std::deque<std::string> outbox;
+        bool writing{false};
+        bool closeRequested{false};
+        std::string pendingCloseReason;
+
+        std::once_flag closedOnce;
+        std::promise<std::string> onClosedPromise;
+        std::shared_future<std::string> onClosedFuture{onClosedPromise.get_future().share()};
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/net/server/connection_registry.h
+++ b/engine/include/lights/core/net/server/connection_registry.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include "connection_handler.h"
+
+namespace OZZ::net::server {
+
+    // Builds the delegate for a freshly-accepted connection. Supplied by the app at
+    // registry-construction time -- keeps the registry itself free of any app-specific
+    // knowledge (databases, schemas, etc).
+    using ConnectionFactory = std::function<std::shared_ptr<ConnectionDelegate>(ConnectionHandler&)>;
+
+    // Connections live across N reactor threads, so the mutex guards concurrent access.
+    class ConnectionRegistry {
+    public:
+        explicit ConnectionRegistry(ConnectionFactory factory);
+
+        std::shared_ptr<ConnectionHandler> NewConnection(tcp::socket&& socket);
+        std::shared_ptr<ConnectionHandler> GetConnection(uint64_t id);
+
+    private:
+        void connectionDropped(uint64_t id);
+
+        ConnectionFactory factory;
+        std::atomic<uint64_t> nextId{1};
+
+        std::mutex mutex;
+        std::unordered_map<uint64_t, std::shared_ptr<ConnectionHandler>> connections;
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/net/server/reactor_pool.h
+++ b/engine/include/lights/core/net/server/reactor_pool.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <functional>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace OZZ::net::server {
+
+    namespace asio = boost::asio;
+
+    // Owns N io_context worker threads (0 -> std::thread::hardware_concurrency()).
+    // Start()/Stop() manage the threads; Contexts() is what Server round-robins across.
+    class ReactorPool {
+    public:
+        explicit ReactorPool(unsigned threadCount = 0);
+        ~ReactorPool();
+
+        ReactorPool(const ReactorPool&) = delete;
+        ReactorPool& operator=(const ReactorPool&) = delete;
+
+        void Start();
+        void Stop();
+
+        std::vector<std::reference_wrapper<asio::io_context>> Contexts();
+
+    private:
+        std::vector<std::unique_ptr<asio::io_context>> contexts;
+        std::vector<asio::executor_work_guard<asio::io_context::executor_type>> workGuards;
+        std::vector<std::thread> threads;
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/net/server/server.h
+++ b/engine/include/lights/core/net/server/server.h
@@ -6,8 +6,10 @@
 #include <boost/system/error_code.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -27,7 +29,9 @@ namespace OZZ::net::server {
     // handler captures shared_from_this(), which is UB unless owned by a shared_ptr.
     class Server : public std::enable_shared_from_this<Server> {
     public:
-        static std::shared_ptr<Server> Create(const tcp::endpoint& endpoint,
+        // bindHost is a plain address literal ("0.0.0.0", "127.0.0.1", "::1", ...), not a
+        // URL -- keeps Boost::Asio's endpoint type out of the caller's includes entirely.
+        static std::shared_ptr<Server> Create(const std::string& bindHost, uint16_t port,
                                               ConnectionRegistry& registry,
                                               ServerSettings settings = {});
 
@@ -42,7 +46,7 @@ namespace OZZ::net::server {
         bool IsListening() const;
 
     private:
-        Server(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings);
+        Server(const std::string& bindHost, uint16_t port, ConnectionRegistry& registry, ServerSettings settings);
 
         void doAccept();
         void onAccept(boost::system::error_code ec, tcp::socket socket);

--- a/engine/include/lights/core/net/server/server.h
+++ b/engine/include/lights/core/net/server/server.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include "reactor_pool.h"
+#include "server_settings.h"
+
+namespace OZZ::net::server {
+
+    class ConnectionRegistry;
+
+    namespace asio = boost::asio;
+    using tcp      = asio::ip::tcp;
+
+    // Self-contained server bootstrap: owns a dedicated single-thread accept io_context
+    // (isolated from I/O so connection bursts don't compete with reads/writes) plus a
+    // ReactorPool for accepted sockets. Constructed only via Create() -- the accept
+    // handler captures shared_from_this(), which is UB unless owned by a shared_ptr.
+    class Server : public std::enable_shared_from_this<Server> {
+    public:
+        static std::shared_ptr<Server> Create(const tcp::endpoint& endpoint,
+                                              ConnectionRegistry& registry,
+                                              ServerSettings settings = {});
+
+        ~Server();
+
+        // Starts the acceptor thread, the reactor pool, and the accept loop.
+        void Start();
+
+        // Idempotent. Stops accepting, stops the reactor pool, and joins the acceptor thread.
+        void Stop();
+
+        bool IsListening() const;
+
+    private:
+        Server(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings);
+
+        void doAccept();
+        void onAccept(boost::system::error_code ec, tcp::socket socket);
+
+        asio::io_context acceptorIoc{1};
+        // Without this, run() sees no work queued yet and returns immediately, leaving
+        // the acceptor thread dead before doAccept() ever gets a chance to register work.
+        std::optional<asio::executor_work_guard<asio::io_context::executor_type>> acceptorWorkGuard;
+        std::thread acceptorThread;
+        ReactorPool pool;
+        std::vector<std::reference_wrapper<asio::io_context>> targetContexts;
+
+        tcp::acceptor acceptor;
+        std::size_t nextTarget{0};
+        ConnectionRegistry& registry;
+        bool running{false};
+        // Set only once open/bind/listen all succeed -- acceptor.is_open() alone stays
+        // true after open() even if the later bind() (e.g. port in use) fails.
+        bool listening{false};
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/net/server/server_settings.h
+++ b/engine/include/lights/core/net/server/server_settings.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace OZZ::net::server {
+
+    // Deliberately its own header with no Boost/Asio includes, so consumers can embed
+    // this in a config struct without pulling networking headers into config code.
+    struct ServerSettings {
+        // 0 = std::thread::hardware_concurrency()
+        unsigned reactorThreadCount{0};
+    };
+
+} // namespace OZZ::net::server

--- a/engine/include/lights/core/util/assert.h
+++ b/engine/include/lights/core/util/assert.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
+// Logs via spdlog::error before asserting, so the failure is visible even in a
+// release build where NDEBUG strips assert() (and its condition) entirely.
+#define OZZ_ASSERT(condition, message)   \
+    do {                                 \
+        if (!(condition)) {              \
+            spdlog::error("{}", message); \
+        }                                \
+        assert((condition) && message);  \
+    } while (0)

--- a/engine/src/core/net/server/connection_handler.cpp
+++ b/engine/src/core/net/server/connection_handler.cpp
@@ -1,0 +1,139 @@
+#ifndef __EMSCRIPTEN__
+
+#include "lights/core/net/server/connection_handler.h"
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
+namespace OZZ::net::server {
+
+    ConnectionHandler::ConnectionHandler(tcp::socket&& socket, uint64_t id, std::function<void(uint64_t)> onClosedCallback)
+        : ws(std::move(socket))
+        , id(id)
+        , onClosedCallback(std::move(onClosedCallback)) {}
+
+    void ConnectionHandler::SetDelegate(std::shared_ptr<ConnectionDelegate> newDelegate) {
+        delegate = std::move(newDelegate);
+    }
+
+    void ConnectionHandler::Run() {
+        assert(delegate && "ConnectionHandler::Run() requires SetDelegate() to have been called first");
+
+        // dispatch not post: already on this socket's executor when called, so it runs inline.
+        asio::dispatch(ws.get_executor(), [self = shared_from_this()] {
+            self->ws.set_option(websocket::stream_base::timeout::suggested(beast::role_type::server));
+            self->ws.async_accept(beast::bind_front_handler(&ConnectionHandler::onAccept, self));
+        });
+    }
+
+    void ConnectionHandler::onAccept(beast::error_code ec) {
+        if (ec) {
+            spdlog::warn("Connection {} handshake failed: {}", id, ec.message());
+            doClose("Handshake failed");
+            return;
+        }
+        delegate->OnOpen();
+        doRead();
+    }
+
+    void ConnectionHandler::doRead() {
+        ws.async_read(buffer, beast::bind_front_handler(&ConnectionHandler::onRead, shared_from_this()));
+    }
+
+    void ConnectionHandler::onRead(beast::error_code ec, [[maybe_unused]] std::size_t bytesTransferred) {
+        if (ec == websocket::error::closed) {
+            doClose("Connection closed");
+            return;
+        }
+        if (ec) {
+            doClose("Read error: " + ec.message());
+            return;
+        }
+
+        // Keep the delegate alive for the whole call: OnMessage() may call SetDelegate(),
+        // which would otherwise drop the last reference to the object still executing.
+        auto currentDelegate = delegate;
+        currentDelegate->OnMessage({static_cast<const uint8_t*>(buffer.data().data()), buffer.size()}, ws.got_binary());
+
+        buffer.consume(buffer.size());
+        doRead();
+    }
+
+    void ConnectionHandler::Send(std::string payload) {
+        asio::post(ws.get_executor(), [self = shared_from_this(), payload = std::move(payload)]() mutable {
+            self->enqueueAndMaybeWrite(std::move(payload));
+        });
+    }
+
+    void ConnectionHandler::enqueueAndMaybeWrite(std::string payload) {
+        outbox.push_back(std::move(payload));
+        if (writing) {
+            // Write already in flight (Beast allows only one); onWrite() will pick this up.
+            return;
+        }
+
+        writing = true;
+        ws.binary(true);
+        ws.async_write(asio::buffer(outbox.front()), beast::bind_front_handler(&ConnectionHandler::onWrite, shared_from_this()));
+    }
+
+    void ConnectionHandler::onWrite(beast::error_code ec, [[maybe_unused]] std::size_t bytesTransferred) {
+        if (ec) {
+            doClose("Write error: " + ec.message());
+            return;
+        }
+
+        outbox.pop_front();
+        if (!outbox.empty()) {
+            ws.async_write(asio::buffer(outbox.front()), beast::bind_front_handler(&ConnectionHandler::onWrite, shared_from_this()));
+            return;
+        }
+
+        writing = false;
+        if (closeRequested) {
+            doClose(pendingCloseReason);
+        }
+    }
+
+    void ConnectionHandler::Kill(const std::string& killReason) {
+        asio::post(ws.get_executor(), [self = shared_from_this(), killReason] {
+            self->requestClose(killReason);
+        });
+    }
+
+    void ConnectionHandler::requestClose(const std::string& reason) {
+        closeRequested = true;
+        pendingCloseReason = reason;
+        if (!writing) {
+            doClose(reason);
+        }
+        // else: onWrite() will call doClose() once the outbox has drained.
+    }
+
+    void ConnectionHandler::doClose(const std::string& reason) {
+        std::call_once(closedOnce, [&] {
+            onClosedPromise.set_value(reason);
+            if (onClosedCallback) {
+                onClosedCallback(id);
+            }
+            if (delegate) {
+                auto currentDelegate = delegate;
+                currentDelegate->OnClose(reason);
+            }
+        });
+
+        if (ws.is_open()) {
+            ws.async_close(websocket::close_code::normal, [self = shared_from_this()](beast::error_code) {
+                // Nothing to do -- the socket is torn down once the last shared_ptr to `self` drops.
+            });
+        }
+    }
+
+    std::shared_future<std::string> ConnectionHandler::OnClosed() {
+        return onClosedFuture;
+    }
+
+} // namespace OZZ::net::server
+
+#endif // !__EMSCRIPTEN__

--- a/engine/src/core/net/server/connection_handler.cpp
+++ b/engine/src/core/net/server/connection_handler.cpp
@@ -2,9 +2,9 @@
 
 #include "lights/core/net/server/connection_handler.h"
 
-#include <spdlog/spdlog.h>
+#include "lights/core/util/assert.h"
 
-#include <cassert>
+#include <spdlog/spdlog.h>
 
 namespace OZZ::net::server {
 
@@ -18,7 +18,7 @@ namespace OZZ::net::server {
     }
 
     void ConnectionHandler::Run() {
-        assert(delegate && "ConnectionHandler::Run() requires SetDelegate() to have been called first");
+        OZZ_ASSERT(delegate, "ConnectionHandler::Run() requires SetDelegate() to have been called first");
 
         // dispatch not post: already on this socket's executor when called, so it runs inline.
         asio::dispatch(ws.get_executor(), [self = shared_from_this()] {

--- a/engine/src/core/net/server/connection_registry.cpp
+++ b/engine/src/core/net/server/connection_registry.cpp
@@ -1,0 +1,45 @@
+#ifndef __EMSCRIPTEN__
+
+#include "lights/core/net/server/connection_registry.h"
+
+#include <spdlog/spdlog.h>
+
+namespace OZZ::net::server {
+
+    ConnectionRegistry::ConnectionRegistry(ConnectionFactory factory) : factory(std::move(factory)) {}
+
+    std::shared_ptr<ConnectionHandler> ConnectionRegistry::NewConnection(tcp::socket&& socket) {
+        const uint64_t id = nextId.fetch_add(1, std::memory_order_relaxed);
+
+        auto connection = std::make_shared<ConnectionHandler>(std::move(socket), id,
+            [this](uint64_t droppedId) { connectionDropped(droppedId); });
+        connection->SetDelegate(factory(*connection));
+
+        {
+            std::scoped_lock lock(mutex);
+            connections.emplace(id, connection);
+        }
+
+        spdlog::info("New connection {}", id);
+        connection->Run();
+        return connection;
+    }
+
+    void ConnectionRegistry::connectionDropped(uint64_t id) {
+        std::scoped_lock lock(mutex);
+        if (connections.erase(id) == 0) {
+            spdlog::error("Failed to remove connection {} from connection registry.", id);
+            return;
+        }
+        spdlog::info("Connection {} dropped", id);
+    }
+
+    std::shared_ptr<ConnectionHandler> ConnectionRegistry::GetConnection(uint64_t id) {
+        std::scoped_lock lock(mutex);
+        auto it = connections.find(id);
+        return it == connections.end() ? nullptr : it->second;
+    }
+
+} // namespace OZZ::net::server
+
+#endif // !__EMSCRIPTEN__

--- a/engine/src/core/net/server/reactor_pool.cpp
+++ b/engine/src/core/net/server/reactor_pool.cpp
@@ -1,0 +1,59 @@
+#ifndef __EMSCRIPTEN__
+
+#include "lights/core/net/server/reactor_pool.h"
+
+#include <algorithm>
+
+namespace OZZ::net::server {
+
+    ReactorPool::ReactorPool(unsigned threadCount) {
+        const unsigned count = threadCount == 0 ? std::max(1u, std::thread::hardware_concurrency()) : threadCount;
+        contexts.reserve(count);
+        for (unsigned i = 0; i < count; ++i) {
+            contexts.push_back(std::make_unique<asio::io_context>());
+        }
+    }
+
+    ReactorPool::~ReactorPool() { Stop(); }
+
+    void ReactorPool::Start() {
+        if (!threads.empty()) return;
+
+        // Without a work guard, run() returns immediately (no work queued yet) and every
+        // reactor thread exits before ever seeing a connection.
+        workGuards.reserve(contexts.size());
+        for (auto& ctx : contexts) {
+            workGuards.push_back(asio::make_work_guard(*ctx));
+        }
+
+        threads.reserve(contexts.size());
+        for (auto& ctx : contexts) {
+            threads.emplace_back([&ctx] { ctx->run(); });
+        }
+    }
+
+    void ReactorPool::Stop() {
+        if (threads.empty()) return;
+
+        workGuards.clear();
+        for (auto& ctx : contexts) {
+            ctx->stop();
+        }
+        for (auto& t : threads) {
+            if (t.joinable()) t.join();
+        }
+        threads.clear();
+    }
+
+    std::vector<std::reference_wrapper<asio::io_context>> ReactorPool::Contexts() {
+        std::vector<std::reference_wrapper<asio::io_context>> refs;
+        refs.reserve(contexts.size());
+        for (auto& ctx : contexts) {
+            refs.emplace_back(*ctx);
+        }
+        return refs;
+    }
+
+} // namespace OZZ::net::server
+
+#endif // !__EMSCRIPTEN__

--- a/engine/src/core/net/server/server.cpp
+++ b/engine/src/core/net/server/server.cpp
@@ -4,15 +4,23 @@
 
 #include "lights/core/net/server/connection_registry.h"
 
+#include <boost/asio/ip/address.hpp>
 #include <spdlog/spdlog.h>
 
 namespace OZZ::net::server {
 
-    Server::Server(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings)
+    Server::Server(const std::string& bindHost, uint16_t port, ConnectionRegistry& registry, ServerSettings settings)
         : pool(settings.reactorThreadCount)
         , acceptor(acceptorIoc)
         , registry(registry) {
         boost::system::error_code ec;
+
+        const auto address = asio::ip::make_address(bindHost, ec);
+        if (ec) {
+            spdlog::error("Server: invalid bind address '{}': {}", bindHost, ec.message());
+            return;
+        }
+        const tcp::endpoint endpoint{address, port};
 
         acceptor.open(endpoint.protocol(), ec);
         if (ec) {
@@ -41,8 +49,8 @@ namespace OZZ::net::server {
         listening = true;
     }
 
-    std::shared_ptr<Server> Server::Create(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings) {
-        return std::shared_ptr<Server>(new Server(endpoint, registry, settings));
+    std::shared_ptr<Server> Server::Create(const std::string& bindHost, uint16_t port, ConnectionRegistry& registry, ServerSettings settings) {
+        return std::shared_ptr<Server>(new Server(bindHost, port, registry, settings));
     }
 
     Server::~Server() { Stop(); }

--- a/engine/src/core/net/server/server.cpp
+++ b/engine/src/core/net/server/server.cpp
@@ -1,0 +1,109 @@
+#ifndef __EMSCRIPTEN__
+
+#include "lights/core/net/server/server.h"
+
+#include "lights/core/net/server/connection_registry.h"
+
+#include <spdlog/spdlog.h>
+
+namespace OZZ::net::server {
+
+    Server::Server(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings)
+        : pool(settings.reactorThreadCount)
+        , acceptor(acceptorIoc)
+        , registry(registry) {
+        boost::system::error_code ec;
+
+        acceptor.open(endpoint.protocol(), ec);
+        if (ec) {
+            spdlog::error("Server: open failed: {}", ec.message());
+            return;
+        }
+
+        acceptor.set_option(asio::socket_base::reuse_address(true), ec);
+        if (ec) {
+            spdlog::error("Server: set_option(reuse_address) failed: {}", ec.message());
+            return;
+        }
+
+        acceptor.bind(endpoint, ec);
+        if (ec) {
+            spdlog::error("Server: bind failed: {}", ec.message());
+            return;
+        }
+
+        acceptor.listen(asio::socket_base::max_listen_connections, ec);
+        if (ec) {
+            spdlog::error("Server: listen failed: {}", ec.message());
+            return;
+        }
+
+        listening = true;
+    }
+
+    std::shared_ptr<Server> Server::Create(const tcp::endpoint& endpoint, ConnectionRegistry& registry, ServerSettings settings) {
+        return std::shared_ptr<Server>(new Server(endpoint, registry, settings));
+    }
+
+    Server::~Server() { Stop(); }
+
+    void Server::Start() {
+        if (!listening) {
+            spdlog::error("Server: not starting -- acceptor failed to open (see earlier error).");
+            return;
+        }
+        if (running) return;
+        running = true;
+
+        acceptorWorkGuard.emplace(acceptorIoc.get_executor());
+        pool.Start();
+        targetContexts = pool.Contexts();
+        acceptorThread = std::thread([this] { acceptorIoc.run(); });
+        doAccept();
+    }
+
+    void Server::Stop() {
+        if (!running) return;
+        running = false;
+
+        // Closing (not stop()-ing the io_context) aborts the pending async_accept, whose
+        // handler then sees running == false and doesn't re-arm -- letting run() drain and
+        // return on its own once the work guard below is released. This also releases the
+        // shared_ptr captured by that pending accept handler, which would otherwise keep
+        // this Server alive indefinitely (a self-referential leak via acceptorIoc).
+        boost::system::error_code ec;
+        acceptor.close(ec);
+        acceptorWorkGuard.reset();
+
+        if (acceptorThread.joinable()) {
+            acceptorThread.join();
+        }
+        pool.Stop();
+    }
+
+    bool Server::IsListening() const { return listening; }
+
+    void Server::doAccept() {
+        asio::io_context& target = targetContexts[nextTarget].get();
+        nextTarget = (nextTarget + 1) % targetContexts.size();
+
+        acceptor.async_accept(target, [self = shared_from_this()](boost::system::error_code ec, tcp::socket socket) {
+            self->onAccept(ec, std::move(socket));
+        });
+    }
+
+    void Server::onAccept(boost::system::error_code ec, tcp::socket socket) {
+        if (ec) {
+            spdlog::error("Server: accept failed: {}", ec.message());
+        } else {
+            registry.NewConnection(std::move(socket));
+        }
+
+        if (running) {
+            doAccept();
+        }
+    }
+
+} // namespace OZZ::net::server
+
+#endif // !__EMSCRIPTEN__

--- a/engine/src/core/net/web_socket_boost.cpp
+++ b/engine/src/core/net/web_socket_boost.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <utility>
 
 namespace OZZ::net {
 
@@ -92,8 +93,8 @@ namespace OZZ::net {
                 ioc.restart();
             }
 
-            void sendBinary(const std::string& data) override { send(data); }
-            void sendText(const std::string& data) override { send(data); }
+            void sendBinary(const std::string& data) override { send(data, true); }
+            void sendText(const std::string& data) override { send(data, false); }
 
             void poll() override {
                 std::deque<WebSocketMessage> drained;
@@ -182,20 +183,20 @@ namespace OZZ::net {
                 doRead();
             }
 
-            void send(const std::string& data) {
-                asio::post(ioc, [this, data] { enqueueAndMaybeWrite(data); });
+            void send(const std::string& data, bool binary) {
+                asio::post(ioc, [this, data, binary] { enqueueAndMaybeWrite(data, binary); });
             }
 
-            void enqueueAndMaybeWrite(std::string payload) {
-                outbox.push_back(std::move(payload));
+            void enqueueAndMaybeWrite(std::string payload, bool binary) {
+                outbox.emplace_back(std::move(payload), binary);
                 if (writing) {
                     // Write already in flight (Beast allows only one); onWrite() will pick this up.
                     return;
                 }
 
                 writing = true;
-                ws.binary(true);
-                ws.async_write(asio::buffer(outbox.front()), [this](const beast::error_code ec, const std::size_t bytesTransferred) {
+                ws.binary(outbox.front().second);
+                ws.async_write(asio::buffer(outbox.front().first), [this](const beast::error_code ec, const std::size_t bytesTransferred) {
                     onWrite(ec, bytesTransferred);
                 });
             }
@@ -208,7 +209,8 @@ namespace OZZ::net {
 
                 outbox.pop_front();
                 if (!outbox.empty()) {
-                    ws.async_write(asio::buffer(outbox.front()), [this](const beast::error_code ec, const std::size_t bytesTransferred) {
+                    ws.binary(outbox.front().second);
+                    ws.async_write(asio::buffer(outbox.front().first), [this](const beast::error_code ec, const std::size_t bytesTransferred) {
                         onWrite(ec, bytesTransferred);
                     });
                     return;
@@ -243,7 +245,7 @@ namespace OZZ::net {
             std::deque<WebSocketMessage> queue;
 
             // Only ever touched on ioc's thread -- see class comment.
-            std::deque<std::string> outbox;
+            std::deque<std::pair<std::string, bool>> outbox; // (payload, binary)
             bool writing{false};
         };
     } // namespace

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -1,0 +1,35 @@
+project(lights_engine_tests)
+
+set(CMAKE_CXX_STANDARD 23)
+
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.17.0
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+include(GoogleTest)
+
+set(SOURCES
+        net/server/connection_handler_tests.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME}
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+        lights_engine
+        GTest::gtest_main
+)
+
+gtest_discover_tests(${PROJECT_NAME})

--- a/engine/tests/harness/test_client.h
+++ b/engine/tests/harness/test_client.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "lights/core/net/web_socket.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace OZZ::net::testing {
+
+    // Thin synchronous wrapper around OZZ::net::WebSocket for tests: the client backend
+    // only delivers events from poll(), so this spins a background thread that polls
+    // continuously and lets test bodies block-and-wait for the next event instead of
+    // juggling callbacks.
+    class TestClient {
+    public:
+        explicit TestClient(const std::string& url) {
+            ws = CreateWebSocket();
+            ws->setUrl(url);
+            ws->setOnMessageCallback([this](const WebSocketMessage& msg) {
+                std::lock_guard lock(mutex);
+                events.push_back(msg);
+                cv.notify_all();
+            });
+            ws->start();
+
+            running = true;
+            pollThread = std::thread([this] {
+                while (running) {
+                    ws->poll();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+            });
+        }
+
+        ~TestClient() {
+            running = false;
+            if (pollThread.joinable()) pollThread.join();
+            ws->stop();
+        }
+
+        TestClient(const TestClient&) = delete;
+        TestClient& operator=(const TestClient&) = delete;
+
+        void sendBinary(const std::string& payload) { ws->sendBinary(payload); }
+        void sendText(const std::string& payload) { ws->sendText(payload); }
+
+        // Waits for the next event of a given type, discarding any others (e.g. Open)
+        // received first. Returns nullopt if the timeout elapses.
+        std::optional<WebSocketMessage> waitForEventType(WebSocketMessageType type,
+                                                          std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+            std::unique_lock lock(mutex);
+            while (true) {
+                auto it = std::find_if(events.begin(), events.end(), [type](const WebSocketMessage& e) {
+                    return e.type == type;
+                });
+                if (it != events.end()) {
+                    WebSocketMessage event = std::move(*it);
+                    events.erase(it);
+                    return event;
+                }
+
+                if (cv.wait_until(lock, deadline) == std::cv_status::timeout) {
+                    return std::nullopt;
+                }
+            }
+        }
+
+    private:
+        std::unique_ptr<WebSocket> ws;
+        std::thread pollThread;
+        std::atomic<bool> running{false};
+        std::mutex mutex;
+        std::condition_variable cv;
+        std::deque<WebSocketMessage> events;
+    };
+
+} // namespace OZZ::net::testing

--- a/engine/tests/harness/test_server.h
+++ b/engine/tests/harness/test_server.h
@@ -3,8 +3,7 @@
 #include "lights/core/net/server/connection_registry.h"
 #include "lights/core/net/server/server.h"
 
-#include <boost/asio/ip/address.hpp>
-
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -21,10 +20,8 @@ namespace OZZ::net::server::testing {
 
             for (int i = 0; i < kMaxTries; ++i) {
                 port = kBasePort + i;
-                auto candidate = Server::Create(
-                    tcp::endpoint{asio::ip::make_address("127.0.0.1"), static_cast<unsigned short>(port)},
-                    registry,
-                    ServerSettings{.reactorThreadCount = 2});
+                auto candidate = Server::Create("127.0.0.1", static_cast<uint16_t>(port), registry,
+                                                ServerSettings{.reactorThreadCount = 2});
 
                 if (candidate->IsListening()) {
                     server = candidate;

--- a/engine/tests/harness/test_server.h
+++ b/engine/tests/harness/test_server.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "lights/core/net/server/connection_registry.h"
+#include "lights/core/net/server/server.h"
+
+#include <boost/asio/ip/address.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace OZZ::net::server::testing {
+
+    // Real Server on loopback, for exercising the connection framework end-to-end.
+    // Multiple reactor threads so cross-thread Send()/Kill() posting gets exercised.
+    class TestServer {
+    public:
+        explicit TestServer(ConnectionFactory factory) : registry(std::move(factory)) {
+            constexpr int kBasePort = 19191;
+            constexpr int kMaxTries = 20;
+
+            for (int i = 0; i < kMaxTries; ++i) {
+                port = kBasePort + i;
+                auto candidate = Server::Create(
+                    tcp::endpoint{asio::ip::make_address("127.0.0.1"), static_cast<unsigned short>(port)},
+                    registry,
+                    ServerSettings{.reactorThreadCount = 2});
+
+                if (candidate->IsListening()) {
+                    server = candidate;
+                    break;
+                }
+            }
+
+            if (!server) {
+                throw std::runtime_error("TestServer: no port available in range starting at " + std::to_string(kBasePort));
+            }
+
+            server->Start();
+        }
+
+        ~TestServer() {
+            if (server) server->Stop();
+        }
+
+        TestServer(const TestServer&) = delete;
+        TestServer& operator=(const TestServer&) = delete;
+
+        std::string url() const { return "ws://127.0.0.1:" + std::to_string(port); }
+
+    private:
+        ConnectionRegistry registry;
+        int port{0};
+        std::shared_ptr<Server> server;
+    };
+
+} // namespace OZZ::net::server::testing

--- a/engine/tests/net/server/connection_handler_tests.cpp
+++ b/engine/tests/net/server/connection_handler_tests.cpp
@@ -1,0 +1,247 @@
+#include "lights/core/net/server/connection_delegate.h"
+#include "lights/core/net/server/connection_handler.h"
+#include "lights/core/net/web_socket.h"
+
+#include "harness/test_client.h"
+#include "harness/test_server.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace OZZ::net::server;
+
+namespace {
+
+    // Records everything that happens to it; thread-safe since callbacks run on a
+    // reactor thread while assertions run on the test thread.
+    class RecordingDelegate : public ConnectionDelegate {
+    public:
+        explicit RecordingDelegate(ConnectionHandler& conn) : conn(conn) {}
+
+        void OnOpen() override {
+            std::lock_guard lock(mutex);
+            opened = true;
+            cv.notify_all();
+        }
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            std::lock_guard lock(mutex);
+            messages.emplace_back(std::string(data.begin(), data.end()), binary);
+            cv.notify_all();
+        }
+
+        void OnClose(const std::string& reason) override {
+            std::lock_guard lock(mutex);
+            closed = true;
+            cv.notify_all();
+        }
+
+        bool WaitForOpen(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, [this] { return opened; });
+        }
+
+        std::optional<std::pair<std::string, bool>> WaitForMessage(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            if (!cv.wait_for(lock, timeout, [this] { return !messages.empty(); })) {
+                return std::nullopt;
+            }
+            auto msg = messages.front();
+            messages.pop_front();
+            return msg;
+        }
+
+        bool WaitForClose(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, [this] { return closed; });
+        }
+
+        ConnectionHandler& conn;
+
+    private:
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool opened{false};
+        bool closed{false};
+        std::deque<std::pair<std::string, bool>> messages;
+    };
+
+    // Echoes every message back to the sender.
+    class EchoDelegate final : public RecordingDelegate {
+    public:
+        using RecordingDelegate::RecordingDelegate;
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            RecordingDelegate::OnMessage(data, binary);
+            conn.Send(std::string(data.begin(), data.end()));
+        }
+    };
+
+} // namespace
+
+TEST(ConnectionHandlerTest, OpenFiresOnConnect) {
+    std::shared_ptr<RecordingDelegate> serverDelegate;
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        serverDelegate = std::make_shared<RecordingDelegate>(conn);
+        return serverDelegate;
+    });
+
+    OZZ::net::testing::TestClient client(server.url());
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    ASSERT_NE(serverDelegate, nullptr);
+    EXPECT_TRUE(serverDelegate->WaitForOpen());
+}
+
+TEST(ConnectionHandlerTest, BinaryMessageRoundTrips) {
+    std::shared_ptr<EchoDelegate> serverDelegate;
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        serverDelegate = std::make_shared<EchoDelegate>(conn);
+        return serverDelegate;
+    });
+
+    OZZ::net::testing::TestClient client(server.url());
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    client.sendBinary("hello");
+
+    auto received = serverDelegate->WaitForMessage();
+    ASSERT_TRUE(received.has_value());
+    EXPECT_EQ(received->first, "hello");
+    EXPECT_TRUE(received->second);
+
+    auto echoed = client.waitForEventType(OZZ::net::WebSocketMessageType::Message);
+    ASSERT_TRUE(echoed.has_value());
+    EXPECT_EQ(echoed->data, "hello");
+    EXPECT_TRUE(echoed->binary);
+}
+
+TEST(ConnectionHandlerTest, TextMessageDeliveredAsNonBinary) {
+    // Unlike the old app-level ClientConnection (which silently dropped text frames),
+    // the generic handler delivers everything -- ignoring non-binary is an app policy now.
+    std::shared_ptr<RecordingDelegate> serverDelegate;
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        serverDelegate = std::make_shared<RecordingDelegate>(conn);
+        return serverDelegate;
+    });
+
+    OZZ::net::testing::TestClient client(server.url());
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    client.sendText("hello");
+
+    auto received = serverDelegate->WaitForMessage();
+    ASSERT_TRUE(received.has_value());
+    EXPECT_EQ(received->first, "hello");
+    EXPECT_FALSE(received->second);
+}
+
+TEST(ConnectionHandlerTest, KillClosesGracefullyAfterOutboxDrains) {
+    class KillOnMessageDelegate final : public RecordingDelegate {
+    public:
+        using RecordingDelegate::RecordingDelegate;
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            RecordingDelegate::OnMessage(data, binary);
+            conn.Send("last words");
+            conn.Kill("test done");
+        }
+    };
+
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        return std::make_shared<KillOnMessageDelegate>(conn);
+    });
+
+    OZZ::net::testing::TestClient client(server.url());
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    client.sendBinary("go");
+
+    auto msg = client.waitForEventType(OZZ::net::WebSocketMessageType::Message);
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg->data, "last words");
+
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Close).has_value());
+}
+
+TEST(ConnectionHandlerTest, SetDelegateSwapsSubsequentMessageHandling) {
+    class SecondDelegate final : public RecordingDelegate {
+    public:
+        using RecordingDelegate::RecordingDelegate;
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            RecordingDelegate::OnMessage(data, binary);
+            conn.Send("from-second");
+        }
+    };
+
+    class FirstDelegate final : public RecordingDelegate {
+    public:
+        FirstDelegate(ConnectionHandler& conn, std::promise<std::shared_ptr<SecondDelegate>> promise)
+            : RecordingDelegate(conn), promise(std::move(promise)) {}
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            RecordingDelegate::OnMessage(data, binary);
+            auto next = std::make_shared<SecondDelegate>(conn);
+            conn.SetDelegate(next);
+            promise.set_value(std::move(next));
+        }
+
+    private:
+        std::promise<std::shared_ptr<SecondDelegate>> promise;
+    };
+
+    std::promise<std::shared_ptr<SecondDelegate>> secondPromise;
+    std::future<std::shared_ptr<SecondDelegate>> secondFuture = secondPromise.get_future();
+
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        return std::make_shared<FirstDelegate>(conn, std::move(secondPromise));
+    });
+
+    OZZ::net::testing::TestClient client(server.url());
+    ASSERT_TRUE(client.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    client.sendBinary("switch");
+
+    ASSERT_EQ(secondFuture.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    auto secondDelegate = secondFuture.get();
+    ASSERT_NE(secondDelegate, nullptr);
+
+    client.sendBinary("second message");
+    auto reply = client.waitForEventType(OZZ::net::WebSocketMessageType::Message);
+    ASSERT_TRUE(reply.has_value());
+    EXPECT_EQ(reply->data, "from-second");
+
+    auto secondReceived = secondDelegate->WaitForMessage();
+    ASSERT_TRUE(secondReceived.has_value());
+    EXPECT_EQ(secondReceived->first, "second message");
+}
+
+TEST(ConnectionHandlerTest, MultipleConnectionsAreIndependent) {
+    OZZ::net::server::testing::TestServer server([&](ConnectionHandler& conn) {
+        return std::make_shared<EchoDelegate>(conn);
+    });
+
+    OZZ::net::testing::TestClient clientA(server.url());
+    OZZ::net::testing::TestClient clientB(server.url());
+
+    ASSERT_TRUE(clientA.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+    ASSERT_TRUE(clientB.waitForEventType(OZZ::net::WebSocketMessageType::Open).has_value());
+
+    clientA.sendBinary("from-a");
+    clientB.sendBinary("from-b");
+
+    auto msgA = clientA.waitForEventType(OZZ::net::WebSocketMessageType::Message);
+    auto msgB = clientB.waitForEventType(OZZ::net::WebSocketMessageType::Message);
+    ASSERT_TRUE(msgA.has_value());
+    ASSERT_TRUE(msgB.has_value());
+    EXPECT_EQ(msgA->data, "from-a");
+    EXPECT_EQ(msgB->data, "from-b");
+}


### PR DESCRIPTION
## Summary
- Ports server-side connection plumbing (accept loop, per-connection read/write/lifecycle) out of truck-kun into Lights as `OZZ::net::server`: `ConnectionDelegate`, `ConnectionHandler`, `ConnectionRegistry`, `ReactorPool`, `ServerSettings`, `Server`.
- Split point: engine owns transport/lifecycle, app owns message schema/business logic via `ConnectionDelegate` (built per-connection by an app-supplied factory injected into `ConnectionRegistry`). `ConnectionHandler` delivers every frame (binary and text) to the delegate untouched — no assumptions about frame-type policy baked into the engine.
- `SetDelegate()` lets a delegate swap itself out mid-connection (e.g. auth phase → gameplay phase) without `ConnectionHandler` needing to know phases exist.
- `Server` now owns its full lifecycle (dedicated single-thread accept context + a `ReactorPool` it manages) via `Server::Create(endpoint, registry, ServerSettings{})` / `Start()` / `Stop()` — no more manual io_context/thread wiring at the call site. `ServerSettings` (currently just `reactorThreadCount`, 0 = auto) is a dependency-free struct meant to be embedded directly in a consumer's own TOML config struct.
- Adds `engine/tests/` (new GoogleTest infra — `engine/` had none before) with a small suite exercising the framework end-to-end via a trivial test delegate: open/message/close delivery, binary vs text tagging, `Send`/`Kill`, `SetDelegate` mid-connection, multiple independent connections.

## Bugs found and fixed getting the new tests to actually pass (not just compile)
- `Server::acceptorIoc` had no work guard — its dedicated thread could see no queued work yet and return almost immediately, leaving the accept loop silently dead forever while the OS-level TCP handshake still completed underneath it (very confusing to debug: client `connect()` succeeds, WebSocket handshake just hangs).
- Client-side `WebSocket` backend (`web_socket_boost.cpp`, from the earlier Boost migration PR): `sendBinary`/`sendText` shared one code path that unconditionally sent binary — text frames were never actually sent as text. Caught by a test that sends text and asserts the server sees `binary == false`.

## Test plan
- [x] `engine/tests/net/server/connection_handler_tests.cpp` — 6 tests, real client+server over loopback, all green (built+linked+run manually outside CMake to sidestep the Vulkan SDK requirement `ozz_rendering` pulls in on full configure in this sandbox; not available here).
- [x] Verified via a real truck-kun server binary + real client end-to-end (see companion PR) — login round-trips correctly through the new framework.
- [ ] Full CMake build with Vulkan SDK available (couldn't run in this sandbox).

Companion PR (depends on this): mauville-technologies/truck-kun#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6rRANHpfQPBzxErH85F3L