### PR TITLE
Add client-side netcode mirroring the server's delegate pattern

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SOURCES
         src/core/net/server/connection_registry.cpp
         src/core/net/server/server.cpp
 
+        src/core/net/client/connection_handler.cpp
+
         src/core/platform/window.cpp
         src/core/platform/SDL3/sdl_keys.cpp
         src/core/platform/SDL3/sdl_window.cpp

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
         src/core/net/server/server.cpp
 
         src/core/net/client/connection_handler.cpp
+        src/core/net/client/client.cpp
 
         src/core/platform/window.cpp
         src/core/platform/SDL3/sdl_keys.cpp

--- a/engine/include/lights/core/net/client/client.h
+++ b/engine/include/lights/core/net/client/client.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "connection_delegate.h"
+#include "connection_handler.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace OZZ::net::client {
+
+    // Builds the delegate for a connection attempt. Supplied by the app at Client
+    // construction time -- keeps Client itself free of app-specific knowledge (mirrors
+    // server::ConnectionFactory / server::ConnectionRegistry).
+    using ConnectionFactory = std::function<std::shared_ptr<ConnectionDelegate>(ConnectionHandler&)>;
+
+    // Top-level client bootstrap, mirroring server::Server: owns the connection and
+    // (re)installs a freshly factory-built delegate on every Start() attempt, the same
+    // way ConnectionRegistry::NewConnection builds a fresh delegate per accepted socket.
+    // There's no accept loop or reactor pool -- a client dials exactly one connection and
+    // drives it entirely from Poll().
+    class Client {
+    public:
+        Client(std::string url, ConnectionFactory factory);
+
+        // Makes exactly one connection attempt -- see ConnectionHandler::Connect(). Safe to
+        // call again (e.g. for a reconnect); each call gets a fresh delegate from the
+        // factory rather than reusing whatever phase the previous connection ended in.
+        void Start();
+        void Stop();
+
+        bool IsConnected() const;
+
+        // Pumps the underlying connection and dispatches any queued events to the
+        // delegate. Call once per frame from the game/update thread.
+        void Poll();
+
+    private:
+        std::string url;
+        ConnectionFactory factory;
+        ConnectionHandler conn;
+    };
+
+} // namespace OZZ::net::client

--- a/engine/include/lights/core/net/client/client.h
+++ b/engine/include/lights/core/net/client/client.h
@@ -3,6 +3,7 @@
 #include "connection_delegate.h"
 #include "connection_handler.h"
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -14,11 +15,21 @@ namespace OZZ::net::client {
     // server::ConnectionFactory / server::ConnectionRegistry).
     using ConnectionFactory = std::function<std::shared_ptr<ConnectionDelegate>(ConnectionHandler&)>;
 
+    enum class ConnectionLifecycle : uint8_t {
+        Disconnected,
+        Connecting,
+        Connected,
+    };
+
     // Top-level client bootstrap, mirroring server::Server: owns the connection and
     // (re)installs a freshly factory-built delegate on every Start() attempt, the same
     // way ConnectionRegistry::NewConnection builds a fresh delegate per accepted socket.
     // There's no accept loop or reactor pool -- a client dials exactly one connection and
     // drives it entirely from Poll().
+    //
+    // Client also tracks its own connection lifecycle from the Open/Close/Error events it
+    // already sees, since that's transport fact rather than app policy. What to *do* about
+    // a drop (retry, backoff, give up) stays the caller's decision -- Client only reports.
     class Client {
     public:
         Client(std::string url, ConnectionFactory factory);
@@ -29,6 +40,13 @@ namespace OZZ::net::client {
         void Start();
         void Stop();
 
+        ConnectionLifecycle GetLifecycle() const { return lifecycle; }
+
+        // True once this Client has reached Connected at least once. Lets a caller tell a
+        // first connection attempt failing apart from an established connection dropping,
+        // without tracking that itself.
+        bool HasConnectedBefore() const { return hasConnectedBefore; }
+
         bool IsConnected() const;
 
         // Pumps the underlying connection and dispatches any queued events to the
@@ -36,9 +54,16 @@ namespace OZZ::net::client {
         void Poll();
 
     private:
+        // Wraps the factory-built delegate so Client can observe Open/Close/Error and keep
+        // `lifecycle`/`hasConnectedBefore` current, without ConnectionHandler or
+        // ConnectionDelegate needing any notion that Client exists.
+        class LifecycleDelegate;
+
         std::string url;
         ConnectionFactory factory;
         ConnectionHandler conn;
+        ConnectionLifecycle lifecycle{ConnectionLifecycle::Disconnected};
+        bool hasConnectedBefore{false};
     };
 
 } // namespace OZZ::net::client

--- a/engine/include/lights/core/net/client/connection_delegate.h
+++ b/engine/include/lights/core/net/client/connection_delegate.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+
+namespace OZZ::net::client {
+
+    // Application-defined message handling for the client's connection to a server.
+    // ConnectionHandler owns exactly one delegate at a time and always dispatches
+    // through it -- SetDelegate() swaps in a new one (e.g. auth -> gameplay) without
+    // ConnectionHandler needing to know phases exist. Mirrors server::ConnectionDelegate;
+    // OnError is the one addition, since a client dial can fail before ever opening,
+    // which has no server-side equivalent.
+    class ConnectionDelegate {
+    public:
+        virtual ~ConnectionDelegate() = default;
+
+        // Fires exactly once per successful connection, right after the socket opens,
+        // on whichever delegate ConnectionHandler::Connect() was called with installed.
+        virtual void OnOpen() {}
+
+        virtual void OnMessage(std::span<const uint8_t> data, bool binary) = 0;
+
+        virtual void OnClose(const std::string& reason) {}
+
+        virtual void OnError(const std::string& reason) {}
+    };
+
+} // namespace OZZ::net::client

--- a/engine/include/lights/core/net/client/connection_handler.h
+++ b/engine/include/lights/core/net/client/connection_handler.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "connection_delegate.h"
+#include "lights/core/net/web_socket.h"
+
+#include <memory>
+#include <string>
+
+namespace OZZ::net::client {
+
+    // Owns the client's single connection to a server and dispatches its events through
+    // a swappable ConnectionDelegate. Mirrors server::ConnectionHandler's delegate model;
+    // unlike the server side, there's exactly one connection and no reactor thread to pin
+    // to -- everything here runs on whatever thread calls Poll().
+    class ConnectionHandler {
+    public:
+        ConnectionHandler();
+
+        // Installs the message handler. Safe to call before Connect() (initial phase) or
+        // from inside a delegate's own OnMessage() (phase transition, e.g. auth -> gameplay).
+        void SetDelegate(std::shared_ptr<ConnectionDelegate> newDelegate);
+
+        // Makes exactly one connection attempt -- see WebSocket::start(). Replaces the
+        // underlying socket, so this also how callers retry after a close/error.
+        void Connect(const std::string& url);
+        void Disconnect();
+
+        void Send(std::string payload);
+
+        // Pumps the underlying WebSocket and dispatches any queued events to the
+        // delegate. Call once per frame from the game/update thread.
+        void Poll();
+
+        bool IsConnected() const { return connected; }
+
+    private:
+        void onWebSocketMessage(const WebSocketMessage& msg);
+
+        std::unique_ptr<WebSocket> ws;
+        std::shared_ptr<ConnectionDelegate> delegate;
+        bool connected{false};
+    };
+
+} // namespace OZZ::net::client

--- a/engine/src/core/net/client/client.cpp
+++ b/engine/src/core/net/client/client.cpp
@@ -1,0 +1,26 @@
+#include "lights/core/net/client/client.h"
+
+#include <utility>
+
+namespace OZZ::net::client {
+
+    Client::Client(std::string url, ConnectionFactory factory) : url(std::move(url)), factory(std::move(factory)) {}
+
+    void Client::Start() {
+        conn.SetDelegate(factory(conn));
+        conn.Connect(url);
+    }
+
+    void Client::Stop() {
+        conn.Disconnect();
+    }
+
+    bool Client::IsConnected() const {
+        return conn.IsConnected();
+    }
+
+    void Client::Poll() {
+        conn.Poll();
+    }
+
+} // namespace OZZ::net::client

--- a/engine/src/core/net/client/client.cpp
+++ b/engine/src/core/net/client/client.cpp
@@ -4,19 +4,52 @@
 
 namespace OZZ::net::client {
 
+    class Client::LifecycleDelegate final : public ConnectionDelegate {
+    public:
+        LifecycleDelegate(Client& owner, std::shared_ptr<ConnectionDelegate> inner)
+            : owner(owner)
+            , inner(std::move(inner)) {}
+
+        void OnOpen() override {
+            owner.lifecycle = ConnectionLifecycle::Connected;
+            owner.hasConnectedBefore = true;
+            if (inner) inner->OnOpen();
+        }
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            if (inner) inner->OnMessage(data, binary);
+        }
+
+        void OnClose(const std::string& reason) override {
+            owner.lifecycle = ConnectionLifecycle::Disconnected;
+            if (inner) inner->OnClose(reason);
+        }
+
+        void OnError(const std::string& reason) override {
+            owner.lifecycle = ConnectionLifecycle::Disconnected;
+            if (inner) inner->OnError(reason);
+        }
+
+    private:
+        Client& owner;
+        std::shared_ptr<ConnectionDelegate> inner;
+    };
+
     Client::Client(std::string url, ConnectionFactory factory) : url(std::move(url)), factory(std::move(factory)) {}
 
     void Client::Start() {
-        conn.SetDelegate(factory(conn));
+        lifecycle = ConnectionLifecycle::Connecting;
+        conn.SetDelegate(std::make_shared<LifecycleDelegate>(*this, factory(conn)));
         conn.Connect(url);
     }
 
     void Client::Stop() {
         conn.Disconnect();
+        lifecycle = ConnectionLifecycle::Disconnected;
     }
 
     bool Client::IsConnected() const {
-        return conn.IsConnected();
+        return lifecycle == ConnectionLifecycle::Connected;
     }
 
     void Client::Poll() {

--- a/engine/src/core/net/client/connection_handler.cpp
+++ b/engine/src/core/net/client/connection_handler.cpp
@@ -1,0 +1,65 @@
+#include "lights/core/net/client/connection_handler.h"
+
+#include <utility>
+
+namespace OZZ::net::client {
+
+    ConnectionHandler::ConnectionHandler() : ws(CreateWebSocket()) {}
+
+    void ConnectionHandler::SetDelegate(std::shared_ptr<ConnectionDelegate> newDelegate) {
+        delegate = std::move(newDelegate);
+    }
+
+    void ConnectionHandler::Connect(const std::string& url) {
+        // Recreate the socket rather than reusing it across attempts: a WebSocket whose
+        // start() already ran (even if it later closed/errored) isn't guaranteed to
+        // produce a fresh connection attempt from a second start() call, so reconnects
+        // need a clean instance each time.
+        ws = CreateWebSocket();
+        ws->setUrl(url);
+        ws->setOnMessageCallback([this](const WebSocketMessage& msg) { onWebSocketMessage(msg); });
+        ws->start();
+    }
+
+    void ConnectionHandler::Disconnect() {
+        connected = false;
+        ws->stop();
+    }
+
+    void ConnectionHandler::Send(std::string payload) {
+        ws->sendBinary(payload);
+    }
+
+    void ConnectionHandler::Poll() {
+        ws->poll();
+    }
+
+    void ConnectionHandler::onWebSocketMessage(const WebSocketMessage& msg) {
+        switch (msg.type) {
+            case WebSocketMessageType::Open:
+                connected = true;
+                if (delegate) delegate->OnOpen();
+                break;
+            case WebSocketMessageType::Close:
+                connected = false;
+                if (delegate) delegate->OnClose(msg.closeInfo.reason);
+                break;
+            case WebSocketMessageType::Error:
+                connected = false;
+                if (delegate) delegate->OnError(msg.errorInfo.reason);
+                break;
+            case WebSocketMessageType::Message: {
+                // Keep the delegate alive for the whole call: OnMessage() may call
+                // SetDelegate(), which would otherwise drop the last reference to the
+                // object still executing (mirrors server::ConnectionHandler::onRead).
+                auto currentDelegate = delegate;
+                if (currentDelegate) {
+                    currentDelegate->OnMessage(
+                        {reinterpret_cast<const uint8_t*>(msg.data.data()), msg.data.size()}, msg.binary);
+                }
+                break;
+            }
+        }
+    }
+
+} // namespace OZZ::net::client

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ include(GoogleTest)
 
 set(SOURCES
         net/server/connection_handler_tests.cpp
+        net/client/connection_handler_tests.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ include(GoogleTest)
 set(SOURCES
         net/server/connection_handler_tests.cpp
         net/client/connection_handler_tests.cpp
+        net/client/client_tests.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/engine/tests/net/client/client_tests.cpp
+++ b/engine/tests/net/client/client_tests.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -115,6 +116,22 @@ namespace {
         OZZ::net::server::ConnectionHandler& conn;
     };
 
+    // Drives Client single-threaded (Poll() interleaved with the condition check on the
+    // calling thread) until `condition` holds or `timeout` elapses -- mirrors how the
+    // real game loop only ever calls Connect()/Poll() from one thread, and avoids the
+    // background-thread races a concurrent Start()/Stop() + Poll() would introduce.
+    bool PollUntil(Client& client, const std::function<bool()>& condition,
+                   std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            client.Poll();
+            if (condition())
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return false;
+    }
+
 } // namespace
 
 TEST(ClientTest, StartConnectsAndDeliversOpenThroughFactoryDelegate) {
@@ -166,23 +183,47 @@ TEST(ClientTest, StartAgainBuildsFreshDelegateFromFactory) {
     // Driven single-threaded (no PollingClient) so Start()/Stop() -- which replace the
     // underlying WebSocket -- never race a background thread's concurrent Poll(), the
     // same way the real game loop only ever calls Connect()/Poll() from one thread.
-    const auto pollUntilOpen = [&](std::chrono::milliseconds timeout) {
-        const auto deadline = std::chrono::steady_clock::now() + timeout;
-        while (std::chrono::steady_clock::now() < deadline) {
-            client.Poll();
-            if (lastDelegate->WaitForOpen(std::chrono::milliseconds(0)))
-                return true;
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
-        }
-        return false;
-    };
+    const auto opened = [&] { return lastDelegate->WaitForOpen(std::chrono::milliseconds(0)); };
 
     client.Start();
-    ASSERT_TRUE(pollUntilOpen(std::chrono::seconds(5)));
+    ASSERT_TRUE(PollUntil(client, opened));
     EXPECT_EQ(factoryCallCount, 1);
 
     client.Stop();
     client.Start();
-    ASSERT_TRUE(pollUntilOpen(std::chrono::seconds(5)));
+    ASSERT_TRUE(PollUntil(client, opened));
     EXPECT_EQ(factoryCallCount, 2);
+}
+
+TEST(ClientTest, LifecycleTracksConnectingThenConnected) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    Client client(server.url(), [](ConnectionHandler&) { return std::make_shared<RecordingDelegate>(); });
+
+    EXPECT_EQ(client.GetLifecycle(), ConnectionLifecycle::Disconnected);
+    EXPECT_FALSE(client.HasConnectedBefore());
+
+    client.Start();
+    EXPECT_EQ(client.GetLifecycle(), ConnectionLifecycle::Connecting);
+
+    ASSERT_TRUE(PollUntil(client, [&] { return client.GetLifecycle() == ConnectionLifecycle::Connected; }));
+    EXPECT_TRUE(client.HasConnectedBefore());
+    EXPECT_TRUE(client.IsConnected());
+}
+
+TEST(ClientTest, HasConnectedBeforeStaysTrueAfterStop) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    Client client(server.url(), [](ConnectionHandler&) { return std::make_shared<RecordingDelegate>(); });
+
+    client.Start();
+    ASSERT_TRUE(PollUntil(client, [&] { return client.GetLifecycle() == ConnectionLifecycle::Connected; }));
+
+    client.Stop();
+    EXPECT_EQ(client.GetLifecycle(), ConnectionLifecycle::Disconnected);
+    EXPECT_TRUE(client.HasConnectedBefore());
 }

--- a/engine/tests/net/client/client_tests.cpp
+++ b/engine/tests/net/client/client_tests.cpp
@@ -1,0 +1,188 @@
+#include "lights/core/net/client/client.h"
+#include "lights/core/net/client/connection_delegate.h"
+#include "lights/core/net/server/connection_delegate.h"
+#include "lights/core/net/server/connection_handler.h"
+
+#include "harness/test_server.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+using namespace OZZ::net::client;
+
+namespace {
+
+    // Records everything that happens to it and lets test bodies block-and-wait, since
+    // Client only delivers events from Poll().
+    class RecordingDelegate : public ConnectionDelegate {
+    public:
+        void OnOpen() override {
+            std::lock_guard lock(mutex);
+            opened = true;
+            cv.notify_all();
+        }
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            std::lock_guard lock(mutex);
+            messages.emplace_back(std::string(data.begin(), data.end()), binary);
+            cv.notify_all();
+        }
+
+        bool WaitForOpen(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, [this] { return opened; });
+        }
+
+        std::optional<std::pair<std::string, bool>> WaitForMessage(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            if (!cv.wait_for(lock, timeout, [this] { return !messages.empty(); })) {
+                return std::nullopt;
+            }
+            auto msg = messages.front();
+            messages.pop_front();
+            return msg;
+        }
+
+    private:
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool opened{false};
+        std::deque<std::pair<std::string, bool>> messages;
+    };
+
+    // Like RecordingDelegate, but also holds the ConnectionHandler the factory handed
+    // it, so the test body can send through it -- mirroring how an app delegate (e.g.
+    // AuthDelegate) sends via the conn reference it was constructed with.
+    class SendingRecordingDelegate final : public RecordingDelegate {
+    public:
+        explicit SendingRecordingDelegate(ConnectionHandler& conn) : conn(conn) {}
+
+        void Send(std::string payload) { conn.Send(std::move(payload)); }
+
+    private:
+        ConnectionHandler& conn;
+    };
+
+    // Polls a Client continuously on a background thread, mirroring how
+    // OZZ::net::testing::TestClient drives the raw WebSocket for tests.
+    class PollingClient {
+    public:
+        PollingClient(std::string url, ConnectionFactory factory) : client(std::move(url), std::move(factory)) {
+            running = true;
+            pollThread = std::thread([this] {
+                while (running) {
+                    client.Poll();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+            });
+        }
+
+        ~PollingClient() {
+            running = false;
+            if (pollThread.joinable()) pollThread.join();
+        }
+
+        PollingClient(const PollingClient&) = delete;
+        PollingClient& operator=(const PollingClient&) = delete;
+
+        Client client;
+
+    private:
+        std::atomic<bool> running{false};
+        std::thread pollThread;
+    };
+
+    // Echoes every message back to the client under test.
+    class EchoServerDelegate final : public OZZ::net::server::ConnectionDelegate {
+    public:
+        explicit EchoServerDelegate(OZZ::net::server::ConnectionHandler& conn) : conn(conn) {}
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            conn.Send(std::string(data.begin(), data.end()));
+        }
+
+    private:
+        OZZ::net::server::ConnectionHandler& conn;
+    };
+
+} // namespace
+
+TEST(ClientTest, StartConnectsAndDeliversOpenThroughFactoryDelegate) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    auto delegate = std::make_shared<RecordingDelegate>();
+    PollingClient client(server.url(), [delegate](ConnectionHandler&) { return delegate; });
+    client.client.Start();
+
+    EXPECT_TRUE(delegate->WaitForOpen());
+}
+
+TEST(ClientTest, MessageRoundTripsThroughFactoryDelegate) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    std::shared_ptr<SendingRecordingDelegate> delegate;
+    PollingClient client(server.url(), [&](ConnectionHandler& conn) {
+        delegate = std::make_shared<SendingRecordingDelegate>(conn);
+        return delegate;
+    });
+    client.client.Start();
+
+    ASSERT_TRUE(delegate->WaitForOpen());
+    delegate->Send("hello");
+
+    auto received = delegate->WaitForMessage();
+    ASSERT_TRUE(received.has_value());
+    EXPECT_EQ(received->first, "hello");
+    EXPECT_TRUE(received->second);
+}
+
+TEST(ClientTest, StartAgainBuildsFreshDelegateFromFactory) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    int factoryCallCount = 0;
+    std::shared_ptr<RecordingDelegate> lastDelegate;
+    Client client(server.url(), [&](ConnectionHandler&) {
+        ++factoryCallCount;
+        lastDelegate = std::make_shared<RecordingDelegate>();
+        return lastDelegate;
+    });
+
+    // Driven single-threaded (no PollingClient) so Start()/Stop() -- which replace the
+    // underlying WebSocket -- never race a background thread's concurrent Poll(), the
+    // same way the real game loop only ever calls Connect()/Poll() from one thread.
+    const auto pollUntilOpen = [&](std::chrono::milliseconds timeout) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            client.Poll();
+            if (lastDelegate->WaitForOpen(std::chrono::milliseconds(0)))
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return false;
+    };
+
+    client.Start();
+    ASSERT_TRUE(pollUntilOpen(std::chrono::seconds(5)));
+    EXPECT_EQ(factoryCallCount, 1);
+
+    client.Stop();
+    client.Start();
+    ASSERT_TRUE(pollUntilOpen(std::chrono::seconds(5)));
+    EXPECT_EQ(factoryCallCount, 2);
+}

--- a/engine/tests/net/client/connection_handler_tests.cpp
+++ b/engine/tests/net/client/connection_handler_tests.cpp
@@ -1,0 +1,197 @@
+#include "lights/core/net/client/connection_delegate.h"
+#include "lights/core/net/client/connection_handler.h"
+#include "lights/core/net/server/connection_delegate.h"
+#include "lights/core/net/server/connection_handler.h"
+
+#include "harness/test_server.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+using namespace OZZ::net::client;
+
+namespace {
+
+    // Records everything that happens to it and lets test bodies block-and-wait, since
+    // client::ConnectionHandler only delivers events from Poll().
+    class RecordingDelegate : public ConnectionDelegate {
+    public:
+        void OnOpen() override {
+            std::lock_guard lock(mutex);
+            opened = true;
+            cv.notify_all();
+        }
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            std::lock_guard lock(mutex);
+            messages.emplace_back(std::string(data.begin(), data.end()), binary);
+            cv.notify_all();
+        }
+
+        void OnClose(const std::string& reason) override {
+            std::lock_guard lock(mutex);
+            closed = true;
+            cv.notify_all();
+        }
+
+        bool WaitForOpen(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, [this] { return opened; });
+        }
+
+        std::optional<std::pair<std::string, bool>> WaitForMessage(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            if (!cv.wait_for(lock, timeout, [this] { return !messages.empty(); })) {
+                return std::nullopt;
+            }
+            auto msg = messages.front();
+            messages.pop_front();
+            return msg;
+        }
+
+        bool WaitForClose(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, [this] { return closed; });
+        }
+
+    private:
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool opened{false};
+        bool closed{false};
+        std::deque<std::pair<std::string, bool>> messages;
+    };
+
+    // Polls a ConnectionHandler continuously on a background thread, mirroring how
+    // OZZ::net::testing::TestClient drives the raw WebSocket for tests.
+    class PollingConnectionHandler {
+    public:
+        PollingConnectionHandler() {
+            running = true;
+            pollThread = std::thread([this] {
+                while (running) {
+                    handler.Poll();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+            });
+        }
+
+        ~PollingConnectionHandler() {
+            running = false;
+            if (pollThread.joinable()) pollThread.join();
+        }
+
+        PollingConnectionHandler(const PollingConnectionHandler&) = delete;
+        PollingConnectionHandler& operator=(const PollingConnectionHandler&) = delete;
+
+        ConnectionHandler handler;
+
+    private:
+        std::atomic<bool> running{false};
+        std::thread pollThread;
+    };
+
+    // Server-side delegate that echoes every message back to the client under test.
+    class EchoServerDelegate final : public OZZ::net::server::ConnectionDelegate {
+    public:
+        explicit EchoServerDelegate(OZZ::net::server::ConnectionHandler& conn) : conn(conn) {}
+
+        void OnMessage(std::span<const uint8_t> data, bool binary) override {
+            conn.Send(std::string(data.begin(), data.end()));
+        }
+
+    private:
+        OZZ::net::server::ConnectionHandler& conn;
+    };
+
+} // namespace
+
+TEST(ClientConnectionHandlerTest, OpenFiresOnConnect) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    auto delegate = std::make_shared<RecordingDelegate>();
+    PollingConnectionHandler client;
+    client.handler.SetDelegate(delegate);
+    client.handler.Connect(server.url());
+
+    EXPECT_TRUE(delegate->WaitForOpen());
+}
+
+TEST(ClientConnectionHandlerTest, BinaryMessageRoundTrips) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    auto delegate = std::make_shared<RecordingDelegate>();
+    PollingConnectionHandler client;
+    client.handler.SetDelegate(delegate);
+    client.handler.Connect(server.url());
+
+    ASSERT_TRUE(delegate->WaitForOpen());
+    client.handler.Send("hello");
+
+    auto received = delegate->WaitForMessage();
+    ASSERT_TRUE(received.has_value());
+    EXPECT_EQ(received->first, "hello");
+    EXPECT_TRUE(received->second);
+}
+
+TEST(ClientConnectionHandlerTest, OnCloseFiresWhenServerCloses) {
+    std::shared_ptr<OZZ::net::server::ConnectionHandler> serverConn;
+    OZZ::net::server::testing::TestServer server([&](OZZ::net::server::ConnectionHandler& conn) {
+        serverConn = conn.shared_from_this();
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    auto delegate = std::make_shared<RecordingDelegate>();
+    PollingConnectionHandler client;
+    client.handler.SetDelegate(delegate);
+    client.handler.Connect(server.url());
+
+    ASSERT_TRUE(delegate->WaitForOpen());
+    serverConn->Kill("test done");
+    // Drop our extra reference now, while the server's io_contexts are still alive:
+    // ConnectionHandler's dtor touches Beast's per-context service, so releasing the
+    // last owner after TestServer has torn its reactors down would be UB.
+    serverConn.reset();
+
+    EXPECT_TRUE(delegate->WaitForClose());
+}
+
+TEST(ClientConnectionHandlerTest, SetDelegateSwapsSubsequentMessageHandling) {
+    OZZ::net::server::testing::TestServer server([](OZZ::net::server::ConnectionHandler& conn) {
+        return std::make_shared<EchoServerDelegate>(conn);
+    });
+
+    auto firstDelegate = std::make_shared<RecordingDelegate>();
+    PollingConnectionHandler client;
+    client.handler.SetDelegate(firstDelegate);
+    client.handler.Connect(server.url());
+
+    ASSERT_TRUE(firstDelegate->WaitForOpen());
+    client.handler.Send("first message");
+
+    auto firstReceived = firstDelegate->WaitForMessage();
+    ASSERT_TRUE(firstReceived.has_value());
+    EXPECT_EQ(firstReceived->first, "first message");
+
+    auto secondDelegate = std::make_shared<RecordingDelegate>();
+    client.handler.SetDelegate(secondDelegate);
+    client.handler.Send("second message");
+
+    auto secondReceived = secondDelegate->WaitForMessage();
+    ASSERT_TRUE(secondReceived.has_value());
+    EXPECT_EQ(secondReceived->first, "second message");
+}


### PR DESCRIPTION
## Summary
- Adds `OZZ::net::client::ConnectionHandler`/`ConnectionDelegate`, mirroring the server's delegate-swap model (`lights/core/net/server/`) for a client's single dialed connection.
- Adds `OZZ::net::client::Client`, a top-level bootstrap mirroring `server::Server`: takes `(url, ConnectionFactory)` and installs a fresh factory-built delegate on every `Start()`.
- `Client` tracks its own connection lifecycle (`Disconnected`/`Connecting`/`Connected`, plus `HasConnectedBefore()`) from the Open/Close/Error events it already observes, via an internal `LifecycleDelegate` wrapper -- transport fact, not policy. Reconnect decisions stay with the caller.

## Test plan
- [x] `lights_engine_tests` builds clean
- [x] All 15 relevant tests pass: 6 `ConnectionHandlerTest.*` (server, unchanged), 4 `ClientConnectionHandlerTest.*`, 5 `ClientTest.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQLA4uQ84ixN6s2gmtV2hw