### PR TITLE
Widen Clay debug view; fix SceneLayerManager GPU-resource-teardown race

### DIFF
--- a/engine/include/lights/framework/scene/scene_layer_manager.h
+++ b/engine/include/lights/framework/scene/scene_layer_manager.h
@@ -46,6 +46,8 @@ namespace OZZ::scene {
                 auto& layer = layers[i];
                 auto& name = layerNames[i];
 
+                // Both empty: a slot pending removal has a cleared name but a non-null
+                // layer, so it's correctly skipped here -- see pendingRemovals.
                 if (name.empty() && !layer) {
                     layer = std::move(newLayer);
                     name = layerName;
@@ -112,7 +114,7 @@ namespace OZZ::scene {
         void InitLayerAsync(const std::string& layerName, rendering::RHIDevice* inDevice);
 
         // Deactivates and frees the layer's name immediately; defers the actual
-        // DeInit()/destroy several ticks (see RemovalDelayTicks).
+        // DeInit()/destroy several ticks (see removalDelayTicks).
         void RemoveLayer(const std::string& layerName);
 
         // Advances pending removals queued by RemoveLayer(). Call once per frame; Scene::Tick
@@ -155,10 +157,13 @@ namespace OZZ::scene {
         std::vector<std::unique_ptr<SceneLayer>> layers;
         std::vector<std::thread> asyncLoadingThreads;
 
-        // A just-deactivated layer's GPU resources/Clay components can still be referenced
-        // this tick; margin is tick-counted (assumes tick rate ~= render rate), not GPU-frame-counted.
-        static constexpr int RemovalDelayTicks = 6;
+        // Set in Init() from device->GetFramesInFlight(); a just-deactivated layer's GPU
+        // resources/Clay components can still be referenced this tick.
+        int removalDelayTicks = 6;
 
+        // Indices stay valid while pending: RemoveLayer clears the name but not the layer
+        // pointer, so LoadLayer's slot-reuse scan won't touch this index meanwhile, and
+        // nothing else shrinks or reorders `layers`.
         struct PendingRemoval {
             size_t Index;
             int TicksRemaining;

--- a/engine/include/lights/framework/scene/scene_layer_manager.h
+++ b/engine/include/lights/framework/scene/scene_layer_manager.h
@@ -77,7 +77,8 @@ namespace OZZ::scene {
         T* LoadLayerDeferred(const std::string& layerName, Args&&... args) {
             for (size_t index = 0; index < layerNames.size(); ++index) {
                 const auto& name = layerNames[index];
-                if (name != layerName) continue;
+                if (name != layerName)
+                    continue;
                 auto* existingLayer = dynamic_cast<T*>(layers[index].get());
                 assert(existingLayer && "Layer name already exists with a different type.");
                 return existingLayer;
@@ -110,7 +111,13 @@ namespace OZZ::scene {
         // LoadLayerDeferred first.
         void InitLayerAsync(const std::string& layerName, rendering::RHIDevice* inDevice);
 
+        // Deactivates and frees the layer's name immediately; defers the actual
+        // DeInit()/destroy several ticks (see RemovalDelayTicks).
         void RemoveLayer(const std::string& layerName);
+
+        // Advances pending removals queued by RemoveLayer(). Call once per frame; Scene::Tick
+        // already does this for every Scene.
+        void Tick();
 
         template <typename LayerType>
         LayerType* GetLayer(const std::string& layerName) {
@@ -136,7 +143,8 @@ namespace OZZ::scene {
 
     private:
         void NotifyLayerProgress(const std::string& layerName, float progress, std::string statusText) {
-            if (OnLayerProgress) OnLayerProgress(layerName, progress, std::move(statusText));
+            if (OnLayerProgress)
+                OnLayerProgress(layerName, progress, std::move(statusText));
         }
 
         rendering::RHIDevice* device{nullptr};
@@ -146,6 +154,17 @@ namespace OZZ::scene {
         std::vector<uint16_t> layerExecutionOrders;
         std::vector<std::unique_ptr<SceneLayer>> layers;
         std::vector<std::thread> asyncLoadingThreads;
+
+        // A just-deactivated layer's GPU resources/Clay components can still be referenced
+        // this tick; margin is tick-counted (assumes tick rate ~= render rate), not GPU-frame-counted.
+        static constexpr int RemovalDelayTicks = 6;
+
+        struct PendingRemoval {
+            size_t Index;
+            int TicksRemaining;
+        };
+
+        std::vector<PendingRemoval> pendingRemovals;
 
         mutable std::vector<SceneLayer*> activeLayersCache;
         mutable bool bActiveLayersCacheDirty = true;

--- a/engine/src/framework/layers/clay/clay_ui_layer.cpp
+++ b/engine/src/framework/layers/clay/clay_ui_layer.cpp
@@ -505,6 +505,10 @@ void ClayUILayer::reinitializeClay() {
                                     this});
     Clay_SetCurrentContext(context);
     Clay_SetDebugModeEnabled(false);
+    // Default 400px is too narrow for our (longer than Clay's own examples)
+    // element IDs -- the debug view's own selected-element name label gets
+    // clipped by the window edge since that row doesn't wrap or clip horizontally.
+    Clay__debugViewWidth = 500;
     Clay_SetMeasureTextFunction(
         [](Clay_StringSlice text, Clay_TextElementConfig* config, void* userData) -> Clay_Dimensions {
             auto* ClayUILayerInstance = static_cast<ClayUILayer*>(userData);

--- a/engine/src/framework/scene/scene.cpp
+++ b/engine/src/framework/scene/scene.cpp
@@ -19,6 +19,8 @@ namespace OZZ {
 
     void scene::Scene::Tick(float DeltaTime) {
         OZZ_PROFILE_FUNCTION;
+        layerManager->Tick();
+
         constexpr float physicsTickRate = 1.f / 60.f;
         physicsAccumulator += DeltaTime;
 

--- a/engine/src/framework/scene/scene_layer_manager.cpp
+++ b/engine/src/framework/scene/scene_layer_manager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "lights/framework/scene/scene_layer_manager.h"
+#include "lights/core/util/assert.h"
 #include "lights/framework/layers/clay/clay_ui_layer.h"
 
 #include <algorithm>
@@ -36,6 +37,9 @@ namespace OZZ::scene {
             layer->Init(device);
         }
         bIsInitialized = true;
+        // 3x the backend's real frames-in-flight -- ticks aren't 1:1 with rendered frames
+        // (Scene::Tick runs even when that iteration doesn't render), so pad past the minimum.
+        removalDelayTicks = static_cast<int>(device->GetFramesInFlight()) * 3;
         LoadLayer<ClayUILayer>(device, "ClayUI");
         SetLayerActive("ClayUI", true);
     }
@@ -49,11 +53,13 @@ namespace OZZ::scene {
                     return layerIndex == index;
                 });
 
-                // Name freed now; layers[index] stays alive a few more ticks (see
-                // RemovalDelayTicks) -- LoadLayer's slot-reuse scan requires both an empty
-                // name and a null layer pointer, so this slot is correctly skipped meanwhile.
+                OZZ_ASSERT(std::ranges::none_of(pendingRemovals,
+                                                [index](const auto& p) {
+                                                    return p.Index == index;
+                                                }),
+                           "index already pending removal");
                 layerNames[index] = "";
-                pendingRemovals.push_back({index, RemovalDelayTicks});
+                pendingRemovals.push_back({index, removalDelayTicks});
                 bActiveLayersCacheDirty = true;
             }
         }

--- a/engine/src/framework/scene/scene_layer_manager.cpp
+++ b/engine/src/framework/scene/scene_layer_manager.cpp
@@ -10,7 +10,8 @@
 namespace OZZ::scene {
     SceneLayerManager::~SceneLayerManager() {
         for (auto& t : asyncLoadingThreads) {
-            if (t.joinable()) t.join();
+            if (t.joinable())
+                t.join();
         }
         activeLayers.clear();
         layerNames.clear();
@@ -19,10 +20,12 @@ namespace OZZ::scene {
 
     void SceneLayerManager::InitLayerAsync(const std::string& layerName, rendering::RHIDevice* inDevice) {
         auto* layer = GetLayer<SceneLayer>(layerName);
-        if (!layer) return;
+        if (!layer)
+            return;
         asyncLoadingThreads.emplace_back([this, layer, inDevice, layerName]() {
             layer->Init(inDevice);
-            if (OnLayerLoaded) OnLayerLoaded(layerName);
+            if (OnLayerLoaded)
+                OnLayerLoaded(layerName);
         });
     }
 
@@ -46,14 +49,27 @@ namespace OZZ::scene {
                     return layerIndex == index;
                 });
 
-                // remove the layer from the names and layers by emptying the slot. We keep the slots empty for re-use
-                // to avoid invalidating the indices
+                // Name freed now; layers[index] stays alive a few more ticks (see
+                // RemovalDelayTicks) -- LoadLayer's slot-reuse scan requires both an empty
+                // name and a null layer pointer, so this slot is correctly skipped meanwhile.
                 layerNames[index] = "";
-                layers[index]->DeInit();
-                layers[index].reset();
+                pendingRemovals.push_back({index, RemovalDelayTicks});
                 bActiveLayersCacheDirty = true;
             }
         }
+    }
+
+    void SceneLayerManager::Tick() {
+        for (auto& pending : pendingRemovals) {
+            --pending.TicksRemaining;
+        }
+        erase_if(pendingRemovals, [this](const PendingRemoval& pending) {
+            if (pending.TicksRemaining > 0)
+                return false;
+            layers[pending.Index]->DeInit();
+            layers[pending.Index].reset();
+            return true;
+        });
     }
 
     void SceneLayerManager::SetLayerActive(const std::string& layerName, bool bActive) {


### PR DESCRIPTION
## Summary
- Widen Clay's built-in debug-overlay panel (400px -> 500px) so long element IDs aren't clipped in the selected-element label.
- Fix an intermittent `VK_ERROR_DEVICE_LOST` crash: `SceneLayerManager::RemoveLayer` destroyed a layer's GPU resources synchronously from `Tick()`, which always runs before that same iteration's `BeginFrame`/`EndFrame` -- so the Vulkan backend's per-frame deferred-deletion queue had no real chance to confirm the GPU was actually done with them. Confirmed via Vulkan validation on real hardware (`vkDestroyImage`/`vkFreeDescriptorSets` on resources still referenced by an in-flight `VkCommandBuffer`). `RemoveLayer` now frees the layer's name immediately but defers the actual `DeInit()`/destroy several ticks; a new `SceneLayerManager::Tick()` (called from `Scene::Tick`) finalizes it once the margin has passed.
- Same fix also protects `idkwtfim2D::GameScene`'s equivalent synchronous `RemoveLayer` calls, which had the same latent race.
- Per review: the removal-delay margin is now sized off the backend's real frames-in-flight (`RHIDevice::GetFramesInFlight()`) instead of a guessed constant, and index-stability across `LoadLayer`'s slot reuse is now asserted, not just implied.

**Depends on** [mauville-technologies/ozz_rendering#1](https://github.com/mauville-technologies/ozz_rendering/pull/1) -- adds `RHIDevice::GetFramesInFlight()`, which the latest commit here calls. Won't build against `ozz_rendering` master until that merges (or `LOCAL_RENDERING_DIR` points at a checkout with it). Please merge ozz_rendering#1 first, or bump the pinned `ozz_rendering` commit alongside this one.

## Test plan
- [x] `idkwtfim2D`, `simple_mmo_client`, `simple_mmo_server` all build clean (Debug, Vulkan, and WebGPU-enabled) against local checkouts of both dependency branches
- [x] Reproduced the original crash on real hardware with Vulkan validation layers enabled (`vkDestroyImage`/`vkFreeDescriptorSets-pDescriptorSets-00309` firing at a scene-layer transition, cascading into `VK_ERROR_DEVICE_LOST`)
- [x] Confirmed fixed: same transition run repeatedly with validation still enabled, no further VUID errors, no device loss
- [x] User-confirmed working end-to-end on their machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mrUuyH2dJNtdobeLGE3vm