### PR TITLE
Make ClayUILayer's tick-function hook owner-tracked

### DIFF
--- a/engine/include/lights/framework/layers/clay/clay_ui_layer.h
+++ b/engine/include/lights/framework/layers/clay/clay_ui_layer.h
@@ -53,7 +53,20 @@ public:
 
     void UnregisterFont(const uint16_t& fontId);
 
-    void SetTickDefinitionFunction(std::function<void()> func) { tickDefinitionFunction = std::move(func); }
+    // Last caller always wins ownership.
+    void SetTickDefinitionFunction(std::function<void()> func, const void* owner) {
+        tickDefinitionFunction = std::move(func);
+        tickDefinitionOwner = owner;
+    }
+
+    // No-op if owner isn't the current one -- safe to call unconditionally from DeInit()
+    // without clobbering whichever layer claimed the hook since.
+    void ClearTickDefinitionFunction(const void* owner) {
+        if (owner == tickDefinitionOwner) {
+            tickDefinitionFunction = nullptr;
+            tickDefinitionOwner = nullptr;
+        }
+    }
 
     void SetDebugPanelOpened(bool bOpened);
 
@@ -92,6 +105,7 @@ protected:
 private:
     OZZ::rendering::RHIBufferHandle cameraBuffer{OZZ::rendering::RHIBufferHandle::Null()};
     std::function<void()> tickDefinitionFunction;
+    const void* tickDefinitionOwner{nullptr};
     glm::ivec2 screenSize{0, 0};
 
     // Clay things


### PR DESCRIPTION
## Summary
- `SetTickDefinitionFunction` now takes an `owner` token alongside the callback.
- `ClearTickDefinitionFunction(owner)` only clears the hook if `owner` still owns it; otherwise it's a no-op.

## Why
Follows from the deferred-layer-teardown fix in #20: `SceneLayerManager` now delays a removed layer's actual `DeInit()` by several ticks, so by the time it runs, another layer's `Init()` may have already claimed `ClayUILayer`'s single tick-function hook. The old unconditional-clear pattern in `DeInit()` (`SetTickDefinitionFunction(nullptr)`) would silently kill that other layer's Clay rendering. Owner-tracking makes it safe for every caller to unconditionally clear on teardown.

Flagged by review on truck-kun PR #21 (simple-mmo register-flow), which also has a real, currently-reachable instance of this bug on `idkwtfim2D`'s Menu -> Loading -> Game transition.

## Test plan
- [x] Full truck-kun build (simple_mmo_client/server) against this branch via `LOCAL_LIGHTS_DIR`, verified compiling and existing behavior intact.
- [ ] Consuming truck-kun PR(s) to update all call sites to the new two-arg API (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mrUuyH2dJNtdobeLGE3vm